### PR TITLE
Edit windows product vpc, subnet, security group

### DIFF
--- a/ec2/sc-ec2-windows-ra.yaml
+++ b/ec2/sc-ec2-windows-ra.yaml
@@ -6,46 +6,20 @@ Metadata:
       - Label:
           default: General Configuration
         Parameters:
-          - VPC
           - KeyPair
-          - RemoteAccessCIDR
       - Label:
           default: Windows Instance Configuration
         Parameters:
           - WindowsInstanceType
-          - WindowsSubnet
-          - WindowsRDPPort
           - LatestAmiId
     ParameterLabels:
-      VPC:
-        default: VPC
       KeyPair:
         default: Key Pair
-      RemoteAccessCIDR:
-        default: Remote Access CIDR Block
       WindowsInstanceType:
         default: Windows Instance Type
-      WindowsSubnet:
-        default: Windows Subnet
-      WindowsRDPPort:
-        default: Windows RDP Port
       LatestAmiId:
         default: SSM path for latest Windows AMI ImageId
 Parameters:
-  VPC:
-    Type: AWS::EC2::VPC::Id
-    Description: Select the VPC where the EC2 instances will be created
-    ConstraintDescription: must be an existing VPC
-    Default: vpc-0d92dc681a4078458
-  WindowsSubnet:
-    Type: AWS::EC2::Subnet::Id
-    Description: Select subnet for Windows Instance
-    ConstraintDescription: must be an existing subnet
-  RemoteAccessCIDR:
-    Description: CIDR block to allow access to windows instances
-    Type: String
-    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
-    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
   WindowsInstanceType:
     AllowedValues:
       - t2.nano
@@ -56,13 +30,6 @@ Parameters:
     Default: t2.micro
     Description: Amazon EC2 Windows Instance Type
     Type: String
-  WindowsRDPPort:
-    Description: Windows RDP Port Number
-    Type: Number
-    Default: 3389
-    MinValue: 1025
-    MaxValue: 65535
-    ConstraintDescription: must be a number from 1025 to 65535
   KeyPair:
     Description: Name of existing EC2 key pair for Windows Instances
     Type: AWS::EC2::KeyPair::KeyName
@@ -96,18 +63,21 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Enables SSH Access to Windows EC2 Instance
-      VpcId: !Ref 'VPC'
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-vpc-ra-VPCID'
       SecurityGroupIngress:
         - Description: allow RDP
           IpProtocol: tcp
-          FromPort: !Ref 'WindowsRDPPort'
-          ToPort: !Ref 'WindowsRDPPort'
-          CidrIp: !Ref 'RemoteAccessCIDR'
+          FromPort: 3389
+          ToPort: 3389
+          CidrIp: !ImportValue
+            'Fn::Sub': '${AWS::Region}-sc-vpc-ra-VPCCIDR'
         - Description: allow icmp
           IpProtocol: icmp
           FromPort: '-1'
           ToPort: '-1'
-          CidrIp: !Ref 'RemoteAccessCIDR'
+          CidrIp: !ImportValue
+            'Fn::Sub': '${AWS::Region}-sc-vpc-ra-VPCCIDR'
       SecurityGroupEgress:
         - Description: allow all outgoing
           IpProtocol: '-1'
@@ -117,7 +87,8 @@ Resources:
     Properties:
       ImageId: !Ref 'LatestAmiId'
       InstanceType: !Ref 'WindowsInstanceType'
-      SubnetId: !Ref 'WindowsSubnet'
+      SubnetId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-sc-vpc-ra-SubnetBPrivateID'
       SecurityGroupIds:
         - !Ref 'WindowsSecurityGroup'
       KeyName: !Ref 'KeyPair'
@@ -252,16 +223,8 @@ Outputs:
     Value: !Ref 'WindowsInstance'
   KeyPair:
     Value: !Ref 'KeyPair'
-  WindowsSubet:
-    Value: !Ref 'WindowsSubnet'
   WindowsInstanceType:
     Value: !Ref 'WindowsInstanceType'
-  WindowsRDPPort:
-    Value: !Ref 'WindowsRDPPort'
-  RemoteAccessCIDR:
-    Value: !Ref 'RemoteAccessCIDR'
-  VPC:
-    Value: !Ref 'VPC'
   IAMInstancePatchingRole:
     Value: !Ref 'InstancePatchingRole'
   IAMPatchingInstanceProfile:


### PR DESCRIPTION
apply similar networking decisions for linux product to windows product
Except, do not allow windows to be on public subnet -- don't think there's any use case for that
