### PR TITLE
Setup service catalog product versioning

### DIFF
--- a/ci/taskcat-params-verify-all.json
+++ b/ci/taskcat-params-verify-all.json
@@ -26,5 +26,9 @@
     {
         "ParameterKey": "RepoRootURL",
         "ParameterValue": "https://s3.amazonaws.com/$[taskcat_autobucket]/SCPortfoliosRepo/"
+    },
+    {
+        "ParameterKey": "ProductVersionName",
+        "ParameterValue": "test"
     }
 ]

--- a/ec2/sc-portfolio-ec2.yaml
+++ b/ec2/sc-portfolio-ec2.yaml
@@ -58,6 +58,9 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'Yes'
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -135,6 +138,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-linux.yaml'
       TimeoutInMinutes: 5
   # ec2webserverproduct:
@@ -148,6 +152,7 @@ Resources:
   #         - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
   #       PortfolioId: !Ref 'SCEC2portfolio'
   #       RepoRootURL: !Ref 'RepoRootURL'
+  #       ProductVersionName: !Ref 'ProductVersionName'
   #     TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-webserver.yaml'
   #     TimeoutInMinutes: 5
   ec2windowsproduct:
@@ -161,6 +166,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-windows.yaml'
       TimeoutInMinutes: 5
 Outputs:

--- a/ec2/sc-portfolio-ec2VPC.yaml
+++ b/ec2/sc-portfolio-ec2VPC.yaml
@@ -57,6 +57,9 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'No'
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -134,6 +137,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersiontName: !Ref 'ProductVersiontName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-linux.yaml'
       TimeoutInMinutes: 5
   ec2webserverproduct:
@@ -147,6 +151,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersiontName: !Ref 'ProductVersiontName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-webserver.yaml'
       TimeoutInMinutes: 5
   ec2windowsproduct:
@@ -160,6 +165,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersiontName: !Ref 'ProductVersiontName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-windows.yaml'
       TimeoutInMinutes: 5
   vpcproduct:
@@ -173,6 +179,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersiontName: !Ref 'ProductVersiontName'
       TemplateURL: !Sub '${RepoRootURL}vpc/sc-product-vpc.yaml'
       TimeoutInMinutes: 5
 Outputs:

--- a/ec2/sc-portfolio-ec2VPC.yaml
+++ b/ec2/sc-portfolio-ec2VPC.yaml
@@ -57,7 +57,7 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'No'
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Conditions:
@@ -137,7 +137,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersiontName: !Ref 'ProductVersiontName'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-linux.yaml'
       TimeoutInMinutes: 5
   ec2webserverproduct:
@@ -151,7 +151,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersiontName: !Ref 'ProductVersiontName'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-webserver.yaml'
       TimeoutInMinutes: 5
   ec2windowsproduct:
@@ -165,7 +165,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersiontName: !Ref 'ProductVersiontName'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-windows.yaml'
       TimeoutInMinutes: 5
   vpcproduct:
@@ -179,7 +179,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEC2portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersiontName: !Ref 'ProductVersiontName'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}vpc/sc-product-vpc.yaml'
       TimeoutInMinutes: 5
 Outputs:

--- a/ec2/sc-product-ec2-demowebserver.yaml
+++ b/ec2/sc-product-ec2-demowebserver.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -32,11 +32,11 @@ Resources:
         - Description: NGINX webserver
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-nginx-nokey.yaml'
-          Name: !Sub 'NGINX ${ProductVersiontName}'
+          Name: !Sub 'NGINX ${ProductVersionName}'
         - Description: Apache webserver
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-apache-nokey.yaml'
-          Name: !Sub 'Apache ${ProductVersiontName}'
+          Name: !Sub 'Apache ${ProductVersionName}'
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-demowebserver.yaml
+++ b/ec2/sc-product-ec2-demowebserver.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -29,11 +32,11 @@ Resources:
         - Description: NGINX webserver
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-nginx-nokey.yaml'
-          Name: NGINX v1.0
+          Name: !Sub 'NGINX ${ProductVersiontName}'
         - Description: Apache webserver
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-apache-nokey.yaml'
-          Name: Apache v1.0
+          Name: !Sub 'Apache ${ProductVersiontName}'
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux.yaml
+++ b/ec2/sc-product-ec2-linux.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -31,7 +34,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux.yaml
+++ b/ec2/sc-product-ec2-linux.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -34,7 +34,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-webserver.yaml
+++ b/ec2/sc-product-ec2-webserver.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -37,7 +37,7 @@ Resources:
         - Description: Apache webserver
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-apache.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-webserver.yaml
+++ b/ec2/sc-product-ec2-webserver.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -34,7 +37,7 @@ Resources:
         - Description: Apache webserver
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-apache.yaml'
-          Name: Apache v2.0
+          Name: !Ref ProductVersiontName
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows.yaml
+++ b/ec2/sc-product-ec2-windows.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -34,7 +34,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows.yaml
+++ b/ec2/sc-product-ec2-windows.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scec2windowsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -31,7 +34,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-container-pipeline.yaml
+++ b/ecs/sc-product-container-pipeline.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -32,7 +32,7 @@ Resources:
         - Description: CodePipeline project
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/container-codepipeline-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-container-pipeline.yaml
+++ b/ecs/sc-product-container-pipeline.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -29,7 +32,7 @@ Resources:
         - Description: CodePipeline project
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/container-codepipeline-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatecluster.yaml
+++ b/ecs/sc-product-fargatecluster.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -32,7 +32,7 @@ Resources:
         - Description: Fargate Cluster
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/fargate-private-vpc.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatecluster.yaml
+++ b/ecs/sc-product-fargatecluster.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -29,7 +32,7 @@ Resources:
         - Description: Fargate Cluster
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/fargate-private-vpc.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatetask.yaml
+++ b/ecs/sc-product-fargatetask.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   ECSTaskProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -29,7 +32,7 @@ Resources:
         - Description: Fargate Task
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/fargate-task.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatetask.yaml
+++ b/ecs/sc-product-fargatetask.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -32,7 +32,7 @@ Resources:
         - Description: Fargate Task
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/fargate-task.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/emr/sc-portfolio-emr.yaml
+++ b/emr/sc-portfolio-emr.yaml
@@ -58,6 +58,9 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'Yes'
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -135,6 +138,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEMRportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}emr/sc-product-emr.yaml'
       TimeoutInMinutes: 5
   emrsparkhbaseproduct:
@@ -148,5 +152,6 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCEMRportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}emr/sc-product-emrsparkhbase.yaml'
       TimeoutInMinutes: 5

--- a/emr/sc-product-emr.yaml
+++ b/emr/sc-product-emr.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scemrproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}emr/sc-emr-ra.yaml'
-          Name: v1.1
+          Name: !Ref 'ProductVersionName'
   Associateemr:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/emr/sc-product-emrsparkhbase.yaml
+++ b/emr/sc-product-emrsparkhbase.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scemrproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}emr/sc-emr-SparkHbase.yaml'
-          Name: v1.1
+          Name: !Ref ProductVersionName
   Associateemr:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
@@ -5,6 +5,9 @@ Parameters:
     Description: Password for internal SNOW users
     Type: String
     Default: NevaChang3
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Mappings:
   AMI:
     us-east-1:
@@ -119,7 +122,7 @@ Resources:
         - Description: Base Version
           Info:
             LoadTemplateFromURL: https://s3.amazonaws.com/marketplace-sa-resources/ec2CFT.json
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
@@ -5,7 +5,7 @@ Parameters:
     Description: Password for internal SNOW users
     Type: String
     Default: NevaChang3
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Mappings:
@@ -122,7 +122,7 @@ Resources:
         - Description: Base Version
           Info:
             LoadTemplateFromURL: https://s3.amazonaws.com/marketplace-sa-resources/ec2CFT.json
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
@@ -1,5 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ' This cloudformation template creates resources for the re:inforce workshop.(fdp-1o32smpoh)'
+Parameters:
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Mappings:
   SubnetAZ1:
     us-east-1:
@@ -105,7 +109,7 @@ Resources:
         - Description: Base Version
           Info:
             LoadTemplateFromURL: https://s3.amazonaws.com/marketplace-sa-resources/ec2CFT.json
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ' This cloudformation template creates resources for the re:inforce workshop.(fdp-1o32smpoh)'
 Parameters:
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Mappings:
@@ -109,7 +109,7 @@ Resources:
         - Description: Base Version
           Info:
             LoadTemplateFromURL: https://s3.amazonaws.com/marketplace-sa-resources/ec2CFT.json
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/rds/sc-portfolio-rds.yaml
+++ b/rds/sc-portfolio-rds.yaml
@@ -58,6 +58,9 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'Yes'
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -135,6 +138,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCRDSportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}rds/sc-product-rds-mariadb.yaml'
       TimeoutInMinutes: 5
   rdsmysqlproduct:
@@ -148,6 +152,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCRDSportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}rds/sc-product-rds-mysql.yaml'
       TimeoutInMinutes: 5
   rdsmssqlproduct:
@@ -161,6 +166,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCRDSportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}rds/sc-product-rds-mssql.yaml'
       TimeoutInMinutes: 5
   rdspostgresproduct:
@@ -174,5 +180,6 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCRDSportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}rds/sc-product-rds-postgresql.yaml'
       TimeoutInMinutes: 5

--- a/rds/sc-product-rds-mariadb.yaml
+++ b/rds/sc-product-rds-mariadb.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mariadb-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mariadb.yaml
+++ b/rds/sc-product-rds-mariadb.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mariadb-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mssql.yaml
+++ b/rds/sc-product-rds-mssql.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mssql-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mssql.yaml
+++ b/rds/sc-product-rds-mssql.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mssql-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mysql.yaml
+++ b/rds/sc-product-rds-mysql.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mysql-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mysql.yaml
+++ b/rds/sc-product-rds-mysql.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mysql-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-postgresql.yaml
+++ b/rds/sc-product-rds-postgresql.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-postgresql-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-postgresql.yaml
+++ b/rds/sc-product-rds-postgresql.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-postgresql-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-portfolio-s3.yaml
+++ b/s3/sc-portfolio-s3.yaml
@@ -58,6 +58,9 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'Yes'
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -135,6 +138,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-public.yaml'
       TimeoutInMinutes: 5
   s3privateproduct:
@@ -148,6 +152,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-private.yaml'
       TimeoutInMinutes: 5
   s3privateEncproduct:
@@ -161,6 +166,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-private-enc.yaml'
       TimeoutInMinutes: 5
   s3privateMFAproduct:
@@ -174,6 +180,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-private-mfa.yaml'
       TimeoutInMinutes: 5
   s3privatetransproduct:
@@ -187,5 +194,6 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-private-trans.yaml'
       TimeoutInMinutes: 5

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-mfa.yaml
+++ b/s3/sc-product-s3-private-mfa.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-mfa-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-mfa.yaml
+++ b/s3/sc-product-s3-private-mfa.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-mfa-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-trans.yaml
+++ b/s3/sc-product-s3-private-trans.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-transition-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-trans.yaml
+++ b/s3/sc-product-s3-private-trans.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-transition-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private.yaml
+++ b/s3/sc-product-s3-private.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-cidr-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private.yaml
+++ b/s3/sc-product-s3-private.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-cidr-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-public.yaml
+++ b/s3/sc-product-s3-public.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -33,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-public-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-public.yaml
+++ b/s3/sc-product-s3-public.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -30,7 +33,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-public-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/templates/taskcat-verify-all.yaml
+++ b/templates/taskcat-verify-all.yaml
@@ -29,6 +29,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -57,6 +60,7 @@ Resources:
         LinkedRole1: !Ref 'LinkedRole1'
         LinkedRole2: !Ref 'LinkedRole2'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-portfolio-ec2.yaml'
       TimeoutInMinutes: 5
   STACKvpcportfolio:
@@ -70,6 +74,7 @@ Resources:
         LinkedRole1: !Ref 'LinkedRole1'
         LinkedRole2: !Ref 'LinkedRole2'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}vpc/sc-portfolio-vpc.yaml'
       TimeoutInMinutes: 5
   STACKrdsportfolio:
@@ -83,6 +88,7 @@ Resources:
         LinkedRole1: !Ref 'LinkedRole1'
         LinkedRole2: !Ref 'LinkedRole2'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}rds/sc-portfolio-rds.yaml'
       TimeoutInMinutes: 5
   STACKemrportfolio:
@@ -96,6 +102,7 @@ Resources:
         LinkedRole1: !Ref 'LinkedRole1'
         LinkedRole2: !Ref 'LinkedRole2'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}emr/sc-portfolio-emr.yaml'
       TimeoutInMinutes: 5
   STACKs3portfolio:
@@ -109,5 +116,6 @@ Resources:
         LinkedRole1: !Ref 'LinkedRole1'
         LinkedRole2: !Ref 'LinkedRole2'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-portfolio-s3.yaml'
       TimeoutInMinutes: 5

--- a/vpc/sc-portfolio-vpc.yaml
+++ b/vpc/sc-portfolio-vpc.yaml
@@ -58,6 +58,9 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'Yes'
+  ProductVersionName:
+    Type: String
+    Description: The product version name in the service catalog
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -135,6 +138,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCVPCportfolio'
         RepoRootURL: !Ref 'RepoRootURL'
+        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}vpc/sc-product-vpc.yaml'
       TimeoutInMinutes: 5
 Outputs:

--- a/vpc/sc-product-vpc.yaml
+++ b/vpc/sc-product-vpc.yaml
@@ -13,6 +13,9 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
+  ProductVersiontName:
+    Type: String
+    Description: The product version name in the service catalog
 Resources:
   scvpcproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -31,7 +34,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}vpc/sc-vpc-ra.yaml'
-          Name: v1.0
+          Name: !Ref ProductVersiontName
   Associatevpc:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/vpc/sc-product-vpc.yaml
+++ b/vpc/sc-product-vpc.yaml
@@ -13,7 +13,7 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersiontName:
+  ProductVersionName:
     Type: String
     Description: The product version name in the service catalog
 Resources:
@@ -34,7 +34,7 @@ Resources:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}vpc/sc-vpc-ra.yaml'
-          Name: !Ref ProductVersiontName
+          Name: !Ref 'ProductVersionName'
   Associatevpc:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:


### PR DESCRIPTION
Setup templates so we can pass a product version string when deploying
templates to AWS.  The idea is to tag them in git and have the tag appear
as the product version in AWS service catalog.