### PR TITLE
Fix default and constraint deescription for s3 buckets

### DIFF
--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -11,9 +11,9 @@ Metadata:
 Parameters:
   S3UserARNs:
     Type: CommaDelimitedList
-    Default: "[]"
+    Default: ""
     Description: User ARNs allowed to access S3 Bucket
-    ConstraintDescription: List of ARNs (i.e. ["arn:aws:iam::011223344556:user/jsmith", "arn:aws:iam::544332211006:user/rjones"]
+    ConstraintDescription: List of ARNs separated by commas (i.e. arn:aws:iam::011223344556:user/jsmith,arn:aws:iam::544332211006:user/rjones)
 Conditions:
   AllowUserAccess: !Not [!Equals [!Join ['', !Ref S3UserARNs], "[]"]]
 Resources:

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -16,9 +16,9 @@ Parameters:
     Default: ""
   S3UserARNs:
     Type: CommaDelimitedList
-    Default: "[]"
+    Default: ""
     Description: User ARNs allowed to access S3 Bucket
-    ConstraintDescription: List of ARNs (i.e. ["arn:aws:iam::011223344556:user/jsmith", "arn:aws:iam::544332211006:user/rjones"]
+    ConstraintDescription: List of ARNs separated by commas (i.e. arn:aws:iam::011223344556:user/jsmith,arn:aws:iam::544332211006:user/rjones)
   BucketName:
     Type: String
     Description: (Optional) Name of the created bucket.


### PR DESCRIPTION
Clears up confusing example which when followed causes template to fail when executed by SC
