### PR TITLE
Add Jumpcloud setup to ec2 template intended for use by ServiceCatalog

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Service Catalog: EC2 Reference Architecture(fdp-1oc5f3ula).'
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E1022
+        - E3012
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -307,7 +312,7 @@ Resources:
               owner: root
               group: root
             /lib/systemd/system/cfn-hup.service:
-              content: !Sub |
+              content: |
                 [Unit]
                 Description=cfn-hup daemon
 
@@ -342,7 +347,7 @@ Resources:
               command: !Join
                 - ''
                 - - "/usr/bin/curl --silent --show-error --header 'x-connect-key: "
-                  - "$(aws ssm get-parameters --names '/infra/JcConnectKey --with-decryption' | jq '.[] | .[0].Value')"
+                  - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
           commands:
@@ -355,13 +360,13 @@ Resources:
                 - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); "
                   - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET https://console.jumpcloud.com/api/systemusers "
                   - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
-                  - "$(aws ssm get-parameters --names '/infra/JcServiceApiKey --with-decryption' | jq '.[] | .[0].Value')"
+                  - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
                   - "' | jq -r '.results | .[] | select(.email==\""
                   - !Ref OwnerEmail
                   - "\") | .id'); "
                   - "/usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations "
                   - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
-                  - "$(aws ssm get-parameters --names '/infra/JcServiceApiKey --with-decryption' | jq '.[] | .[0].Value')"
+                  - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
                   - "' -d '{\"attributes\":{\"sudo\":{\"enabled\":true,\"withoutPassword\":false}},\"op\":\"add\",\"type\":\"system\",\"id\":\"'$JC_SYSTEM_ID'\"}'"
     Properties:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -1,11 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Service Catalog: EC2 Reference Architecture(fdp-1oc5f3ula).'
 Metadata:
-  cfn-lint:
-    config:
-      ignore_checks:
-        - E1022
-        - E3012
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -259,6 +254,11 @@ Resources:
           ToPort: -1
           IpProtocol: '-1'
   PublicSubnetSecurityGroup:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3012
     Type: 'AWS::EC2::SecurityGroup'
     Condition: UsePublicSubnet
     Properties:
@@ -283,6 +283,10 @@ Resources:
   LinuxInstance:
     Type: AWS::EC2::Instance
     Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1022
       'AWS::CloudFormation::Init':
         configSets:
           SetupCfn:
@@ -468,6 +472,11 @@ Resources:
             - !Ref 'LinuxInstance'
       Name: sc-ec2-ra-linux-patch-targets
   LinuxMaintenanceWindowTaskScan:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3012
     Type: AWS::SSM::MaintenanceWindowTask
     Properties:
       MaxErrors: 1
@@ -489,6 +498,11 @@ Resources:
             - Scan
       TaskType: RUN_COMMAND
   LinuxMaintenanceWindowTaskInstall:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3012
     Type: AWS::SSM::MaintenanceWindowTask
     Properties:
       MaxErrors: 1

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -1,0 +1,517 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Service Catalog: EC2 Reference Architecture(fdp-1oc5f3ula).'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: General Configuration
+        Parameters:
+          - PrivateNetwork
+          - OpenPort
+          - OwnerEmail
+      - Label:
+          default: Linux Instance Configuration
+        Parameters:
+          - EC2InstanceType
+          - LinuxDistribution
+    ParameterLabels:
+      PrivateNetwork:
+        default: Use private network?
+      OpenPort:
+        default: Open Port
+      EC2InstanceType:
+        default: EC2 Instance Type
+      LinuxDistribution:
+        default: Linux Distribution
+      OwnerEmail:
+        default: Your Sage Email
+Mappings:
+  LinuxDistributions:
+    Ubuntu:
+      AMIID: ami-04b9e92b5572fa0d1
+    AmazonLinux:
+      AMIID: ami-00068cd7555f543d5
+Parameters:
+  PrivateNetwork:
+    Type: String
+    Description: In the private subnet (recommended) as opposed to a public subnet
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  EC2InstanceType:
+    AllowedValues:
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.12xlarge
+      - c5.18xlarge
+      - c5.24xlarge
+      - c5d.large
+      - c5d.xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.12xlarge
+      - c5d.18xlarge
+      - c5d.24xlarge
+      - c5n.large
+      - c5n.xlarge
+      - c5n.2xlarge
+      - c5n.4xlarge
+      - c5n.9xlarge
+      - c5n.18xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.8xlarge
+      - m5.12xlarge
+      - m5.16xlarge
+      - m5.24xlarge
+      - m5a.large
+      - m5a.xlarge
+      - m5a.2xlarge
+      - m5a.4xlarge
+      - m5a.8xlarge
+      - m5a.12xlarge
+      - m5a.16xlarge
+      - m5a.24xlarge
+      - m5ad.large
+      - m5ad.xlarge
+      - m5ad.2xlarge
+      - m5ad.4xlarge
+      - m5ad.12xlarge
+      - m5ad.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.8xlarge
+      - m5d.12xlarge
+      - m5d.16xlarge
+      - m5d.24xlarge
+      - m5dn.large
+      - m5dn.xlarge
+      - m5dn.2xlarge
+      - m5dn.4xlarge
+      - m5dn.8xlarge
+      - m5dn.12xlarge
+      - m5dn.16xlarge
+      - m5dn.24xlarge
+      - m5n.large
+      - m5n.xlarge
+      - m5n.2xlarge
+      - m5n.4xlarge
+      - m5n.8xlarge
+      - m5n.12xlarge
+      - m5n.16xlarge
+      - m5n.24xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r5.12xlarge
+      - r5.16xlarge
+      - r5.24xlarge
+      - r5a.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5a.12xlarge
+      - r5a.16xlarge
+      - r5a.24xlarge
+      - r5ad.large
+      - r5ad.xlarge
+      - r5ad.2xlarge
+      - r5ad.4xlarge
+      - r5ad.12xlarge
+      - r5ad.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.8xlarge
+      - r5d.12xlarge
+      - r5d.16xlarge
+      - r5d.24xlarge
+      - r5dn.large
+      - r5dn.xlarge
+      - r5dn.2xlarge
+      - r5dn.4xlarge
+      - r5dn.8xlarge
+      - r5dn.12xlarge
+      - r5dn.16xlarge
+      - r5dn.24xlarge
+      - r5n.large
+      - r5n.xlarge
+      - r5n.2xlarge
+      - r5n.4xlarge
+      - r5n.8xlarge
+      - r5n.12xlarge
+      - r5n.16xlarge
+      - r5n.24xlarge
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.nano
+      - t3a.micro
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+    Default: t3.micro
+    Description: Amazon EC2 Instance Type
+    Type: String
+  OpenPort:
+    Description: (Optional) Port to open if on public network
+    Type: String
+    Default: 22
+  LinuxDistribution:
+    Type: String
+    Description: Linux distribution to use for instance operation system
+    Default: AmazonLinux
+    AllowedValues:
+      - AmazonLinux
+      - Ubuntu
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+Conditions:
+  UsePrivateSubnet: !Equals [!Ref PrivateNetwork, 'true']
+  UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']
+  IsUbuntu: !Equals [!Ref LinuxDistribution, 'Ubuntu']
+Resources:
+  InstancePatchingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+  PatchingInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref 'InstancePatchingRole'
+  PrivateSubnetSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Condition: UsePrivateSubnet
+    Properties:
+      GroupDescription: >-
+        Allow all traffic to an instance originating from the VPN
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+      SecurityGroupIngress:
+        - CidrIp: !ImportValue
+            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpcCidr'
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: '-1'
+          Description: 'Allow all VPN traffic'
+      SecurityGroupEgress:
+        - CidrIp: !ImportValue
+            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpcCidr'
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: '-1'
+  PublicSubnetSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Condition: UsePublicSubnet
+    Properties:
+      GroupDescription: Allow SSH to port 22
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+      SecurityGroupIngress:
+        - Description: allow SSH
+          IpProtocol: tcp
+          FromPort: !Ref OpenPort
+          ToPort: !Ref OpenPort
+          CidrIp: '0.0.0.0/0'
+        - Description: allow icmp
+          IpProtocol: icmp
+          FromPort: '-1'
+          ToPort: '-1'
+          CidrIp: '0.0.0.0/0'
+      SecurityGroupEgress:
+        - Description: allow all outgoing
+          IpProtocol: '-1'
+          CidrIp: '0.0.0.0/0'
+  LinuxInstance:
+    Type: AWS::EC2::Instance
+    Metadata:
+      'AWS::CloudFormation::Init':
+        configSets:
+          SetupCfn:
+            - cfn_hup_service
+          SetupJumpcloud:
+            - install_jc
+            - config_jc
+        cfn_hup_service:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+                verbose=true
+                interval=5
+              mode: "000400"
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupJumpcloud,SetupVolume --region ${AWS::Region}
+              mode: "000400"
+              owner: root
+              group: root
+            /lib/systemd/system/cfn-hup.service:
+              content: !Sub |
+                [Unit]
+                Description=cfn-hup daemon
+
+                [Service]
+                Type=simple
+                ExecStart=/opt/aws/bin/cfn-hup
+                Restart=always
+
+                [Install]
+                WantedBy=multi-user.target
+              mode: "000400"
+              owner: root
+              group: root
+          commands:
+            01_enable_cfn-hup:
+              command: "/bin/systemctl enable cfn-hup.service"
+            02_start_cfn-hup:
+              command: "/bin/systemctl start cfn-hup.service"
+        install_jc:
+          packages:
+            !If
+            - IsUbuntu
+            -
+              apt:
+                awscli: []
+                jq: []
+            -
+              yum:
+                jq: []
+          commands:
+            01_jumpcloud_agent:
+              command: !Join
+                - ''
+                - - "/usr/bin/curl --silent --show-error --header 'x-connect-key: "
+                  - "$(aws ssm get-parameters --names '/infra/JcConnectKey --with-decryption' | jq '.[] | .[0].Value')"
+                  #- '{{resolve:ssm-secure:/infra/JcConnectKey:1}}'
+                  - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
+        config_jc:
+          commands:
+            # allow agent time to register with jumpcloud account
+            01_wait_registeration:
+              command: "sleep 10"
+            02_associate_jc_systems:
+              command: !Join
+                - ''
+                - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); "
+                  - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET https://console.jumpcloud.com/api/systemusers "
+                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                  #- '{{resolve:ssm-secure:/infra/JcServiceApiKey:1}}'
+                  - "$(aws ssm get-parameters --names '/infra/JcServiceApiKey --with-decryption' | jq '.[] | .[0].Value')"
+                  - "' | jq -r '.results | .[] | select(.email==\""
+                  - !Ref OwnerEmail
+                  - "\") | .id'); "
+                  - "/usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations "
+                  - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
+                  #- '{{resolve:ssm-secure:/infra/JcServiceApiKey:1}}'
+                  - "$(aws ssm get-parameters --names '/infra/JcServiceApiKey --with-decryption' | jq '.[] | .[0].Value')"
+                  - "' -d '{\"attributes\":{\"sudo\":{\"enabled\":true,\"withoutPassword\":false}},\"op\":\"add\",\"type\":\"system\",\"id\":\"'$JC_SYSTEM_ID'\"}'"
+    Properties:
+      ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
+      InstanceType: !Ref 'EC2InstanceType'
+      SubnetId: !If
+        - UsePrivateSubnet
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+      SecurityGroupIds: !If
+        - UsePrivateSubnet
+        - [!Ref PrivateSubnetSecurityGroup]
+        - [!Ref PublicSubnetSecurityGroup]
+      IamInstanceProfile: !Ref 'PatchingInstanceProfile'
+      Tags:
+        - Key: Description
+          Value: Service-Catalog-EC2-Reference-Architecture
+  LinuxPatchBaseline:
+    Type: AWS::SSM::PatchBaseline
+    Properties:
+      OperatingSystem: AMAZON_LINUX
+      ApprovalRules:
+        PatchRules:
+          - ApproveAfterDays: 0
+            ComplianceLevel: CRITICAL
+            EnableNonSecurity: true
+            PatchFilterGroup:
+              PatchFilters:
+                - Key: PRODUCT
+                  Values:
+                    - '*'
+                - Key: CLASSIFICATION
+                  Values:
+                    - Security
+                    - Bugfix
+                    - Enhancement
+                    - Recommended
+                - Key: SEVERITY
+                  Values:
+                    - Critical
+                    - Important
+                    - Medium
+                    - Low
+      Description: Service Catalog EC2 Reference Architecture Patch Baseline for Amazon
+        Linux instace
+      Name: sc-ec2-ra-linux-patch-baseline
+  MaintenanceWindowRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - ssm.amazonaws.com
+            Action:
+              - sts:AssumeRole
+  MaintenanceWindow:
+    Type: AWS::SSM::MaintenanceWindow
+    Properties:
+      Description: Maintenance window to allow for patching Amazon Linux instances
+      AllowUnassociatedTargets: false
+      Cutoff: 2
+      Schedule: cron(* 17 * * ? *)
+      Duration: 6
+      Name: sc-ec2-ra-linux-maintenance-window
+  LinuxMainteanceWindowTarget:
+    Type: AWS::SSM::MaintenanceWindowTarget
+    Properties:
+      OwnerInformation: Service Catalog EC2 Reference Architecture
+      Description: Service Catalog EC2 Reference Architecture - Patch Maintenance
+        for Amazon Linux Instances
+      WindowId: !Ref 'MaintenanceWindow'
+      ResourceType: INSTANCE
+      Targets:
+        - Key: InstanceIds
+          Values:
+            - !Ref 'LinuxInstance'
+      Name: sc-ec2-ra-linux-patch-targets
+  LinuxMaintenanceWindowTaskScan:
+    Type: AWS::SSM::MaintenanceWindowTask
+    Properties:
+      MaxErrors: 1
+      Description: 'Service Catalog EC2 Reference Architecture Maintenance Window
+        Task: Scan for update for Amazon Linux Instance'
+      ServiceRoleArn: !GetAtt 'MaintenanceWindowRole.Arn'
+      Priority: 1
+      MaxConcurrency: 1
+      Targets:
+        - Key: InstanceIds
+          Values:
+            - !Ref 'LinuxInstance'
+      Name: patch-sc-ec2-ra-linux-instances
+      TaskArn: AWS-RunPatchBaseline
+      WindowId: !Ref 'MaintenanceWindow'
+      TaskParameters:
+        Operation:
+          Values:
+            - Scan
+      TaskType: RUN_COMMAND
+  LinuxMaintenanceWindowTaskInstall:
+    Type: AWS::SSM::MaintenanceWindowTask
+    Properties:
+      MaxErrors: 1
+      Description: 'Service Catalog EC2 Reference Architecture Maintenance Window
+        Task: Install update for Amazon Linux Instance'
+      ServiceRoleArn: !GetAtt 'MaintenanceWindowRole.Arn'
+      Priority: 2
+      MaxConcurrency: 1
+      Targets:
+        - Key: InstanceIds
+          Values:
+            - !Ref 'LinuxInstance'
+      Name: patch-sc-ec2-ra-linux-instances
+      TaskArn: AWS-RunPatchBaseline
+      WindowId: !Ref 'MaintenanceWindow'
+      TaskParameters:
+        Operation:
+          Values:
+            - Install
+      TaskType: RUN_COMMAND
+Outputs:
+  TemplateID:
+    Value: service-catalog-reference-architectures/sc-ec2-ra
+  AWSRegionName:
+    Value: !Ref 'AWS::Region'
+  LinuxInstanceId:
+    Value: !Ref 'LinuxInstance'
+  LinuxInstancePrivateIpAddress:
+    Value: !GetAtt 'LinuxInstance.PrivateIp'
+  LinuxInstanceAvailabilityZone:
+    Value: !GetAtt 'LinuxInstance.AvailabilityZone'
+  EC2InstanceType:
+    Value: !Ref 'EC2InstanceType'
+  OpenPort:
+    Value: !Ref OpenPort
+  IAMInstancePatchingRole:
+    Value: !Ref 'InstancePatchingRole'
+  IAMPatchingInstanceProfile:
+    Value: !Ref 'PatchingInstanceProfile'
+  SSMMaintenaceWindowRole:
+    Value: !Ref 'MaintenanceWindowRole'
+  SSMLinuxPatchBaseline:
+    Value: !Ref 'LinuxPatchBaseline'

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -343,7 +343,6 @@ Resources:
                 - ''
                 - - "/usr/bin/curl --silent --show-error --header 'x-connect-key: "
                   - "$(aws ssm get-parameters --names '/infra/JcConnectKey --with-decryption' | jq '.[] | .[0].Value')"
-                  #- '{{resolve:ssm-secure:/infra/JcConnectKey:1}}'
                   - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
         config_jc:
           commands:
@@ -356,14 +355,12 @@ Resources:
                 - - "JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey'); "
                   - "JC_USER_ID=$(/usr/bin/curl --silent --show-error -X GET https://console.jumpcloud.com/api/systemusers "
                   - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
-                  #- '{{resolve:ssm-secure:/infra/JcServiceApiKey:1}}'
                   - "$(aws ssm get-parameters --names '/infra/JcServiceApiKey --with-decryption' | jq '.[] | .[0].Value')"
                   - "' | jq -r '.results | .[] | select(.email==\""
                   - !Ref OwnerEmail
                   - "\") | .id'); "
                   - "/usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations "
                   - "-H 'Accept: application/json' -H 'Content-Type: application/json' -H 'x-api-key: "
-                  #- '{{resolve:ssm-secure:/infra/JcServiceApiKey:1}}'
                   - "$(aws ssm get-parameters --names '/infra/JcServiceApiKey --with-decryption' | jq '.[] | .[0].Value')"
                   - "' -d '{\"attributes\":{\"sudo\":{\"enabled\":true,\"withoutPassword\":false}},\"op\":\"add\",\"type\":\"system\",\"id\":\"'$JC_SYSTEM_ID'\"}'"
     Properties:
@@ -380,6 +377,21 @@ Resources:
         - [!Ref PrivateSubnetSecurityGroup]
         - [!Ref PublicSubnetSecurityGroup]
       IamInstanceProfile: !Ref 'PatchingInstanceProfile'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          if [[ ${LinuxDistribution} == "Ubuntu" ]]; then
+            export DEBIAN_FRONTEND=noninteractive
+            /usr/bin/apt-get update -y
+            /usr/bin/apt-get install -y python-pip
+            /usr/bin/apt-get install -y python-setuptools
+            /bin/mkdir -p /opt/aws/bin
+            /usr/bin/python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+          else
+            /bin/yum update -y aws-cfn-bootstrap
+          fi
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupJumpcloud --region ${AWS::Region}
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource Ec2Instance --region ${AWS::Region}
       Tags:
         - Key: Description
           Value: Service-Catalog-EC2-Reference-Architecture


### PR DESCRIPTION
This adds init metadata to a ec2 instance template to set register the instance with Jumpcloud. 
- Parameter KeyPair is removed
- Parameter OwnerEmail is added
- No parameters were added for Jumpcloud. The SecureString parameters are pulled from SSM using awscli.

I have left several commented lines where I attempted to use Cloudformation Dynamic References. Unfortunately dynamic references cannot be used in the Parameters section nor in Init sections.

I was not able to fully test this template manually because even when assuming the Admin role I receive a message that I do not have permission to decrypt the strings.