### PR TITLE
Set synapse owner.txt file ACL

### DIFF
--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -86,6 +86,7 @@ Resources:
         Bucket: !Ref S3Bucket
         Key: owner.txt
         ContentType: text
+        ACL: public-read
       Body: !Ref SynapseUserName
 Outputs:
   BucketName:


### PR DESCRIPTION
Using the API to upload the owner.txt file for a synapse bucket requires
setting the ACL public-read otherwise (the principla) synapse
still cannot read the file.