### PR TITLE
update synapse bucket owner.txt file ACL

### DIFF
--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -86,7 +86,7 @@ Resources:
         Bucket: !Ref S3Bucket
         Key: owner.txt
         ContentType: text
-        ACL: public-read
+        ACL: authenticated-read
       Body: !Ref SynapseUserName
 Outputs:
   BucketName:


### PR DESCRIPTION
The more appropriate ACL is authenticated-read[1] as suggested by
@wpoehlm in PR https://github.com/Sage-Bionetworks/synapseDocs/pull/544/commits/ef739561cd5ff99c67ef03e8e23f96305f1898ee

[1] https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html