### PR TITLE
Use sage AMIs

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -28,9 +28,9 @@ Metadata:
 Mappings:
   LinuxDistributions:
     Ubuntu:
-      AMIID: ami-04b9e92b5572fa0d1
+      AMIID: ami-0acb259f7a7b035f6
     AmazonLinux:
-      AMIID: ami-00068cd7555f543d5
+      AMIID: ami-0ca7208f904dc1874
 Parameters:
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-linux-ra.yaml
+++ b/ec2/sc-ec2-linux-ra.yaml
@@ -28,9 +28,9 @@ Metadata:
 Mappings:
   LinuxDistributions:
     Ubuntu:
-      AMIID: ami-04b9e92b5572fa0d1
+      AMIID: ami-0acb259f7a7b035f6
     AmazonLinux:
-      AMIID: ami-00068cd7555f543d5
+      AMIID: ami-0ca7208f904dc1874
 Parameters:
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-windows-ra.yaml
+++ b/ec2/sc-ec2-windows-ra.yaml
@@ -36,7 +36,7 @@ Parameters:
     Type: AWS::EC2::KeyPair::KeyName
   LatestAmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Default: ami-074545a6fb2313e2c
 Resources:
   InstancePatchingRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
The SC linux and windows provisioner templates provision EC2s from AWS published AMIs.
It's not good practice to depend on AMIs from AWS because AWS may deprecate and remove
those AMIs from us at any time. When that happens our templates will be in a broken
state. Instead we will provision instances from Sage AMIs.

This resolves issue #31