### PR TITLE
attempt to fix SC s3 synapse bucket product

### DIFF
--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -41,6 +41,8 @@ Resources:
             Action:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
+              - servicecatalog:ListOrganizationPortfolioAccess
+              - servicecatalog:GetAWSOrganizationsAccessStatus
             Resource: "*"
 Outputs:
   EndUserGroupArn:


### PR DESCRIPTION
SC fails to provision the S3 synapse bucket product. Seeing a few
AccessDenied errors in cloudtrail during provisioning of the bucket.
This is an attempt to allow access to those actions.

fixes https://sagebionetworks.jira.com/browse/SC-14