### PR TITLE
Remove overly permissive SSM policies and patching resources

### DIFF
--- a/ec2/sc-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud.yaml
@@ -55,13 +55,13 @@ Parameters:
     AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
 Resources:
-  InstancePatchingRole:
+  InstanceRole:
     Type: AWS::IAM::Role
     Properties:
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
-        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -71,12 +71,12 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
-  PatchingInstanceProfile:
+  InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles:
-        - !Ref 'InstancePatchingRole'
+        - !Ref 'InstanceRole'
   WindowsSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -197,7 +197,7 @@ Resources:
       SecurityGroupIds:
         - !Ref 'WindowsSecurityGroup'
       KeyName: !Ref 'KeyPair'
-      IamInstanceProfile: !Ref 'PatchingInstanceProfile'
+      IamInstanceProfile: !Ref 'InstanceProfile'
       BlockDeviceMappings:
         -
           DeviceName: "/dev/sda1"
@@ -216,113 +216,6 @@ Resources:
           Value: SC-EC2-RA-Windows-Instance
         - Key: Description
           Value: Service-Catalog-EC2-Reference-Architecture
-  WindowsPatchBaseline:
-    Type: AWS::SSM::PatchBaseline
-    Properties:
-      OperatingSystem: WINDOWS
-      ApprovalRules:
-        PatchRules:
-          - ApproveAfterDays: 0
-            ComplianceLevel: CRITICAL
-            EnableNonSecurity: false
-            PatchFilterGroup:
-              PatchFilters:
-                - Key: PRODUCT
-                  Values:
-                    - WindowsServer2019
-                - Key: CLASSIFICATION
-                  Values:
-                    - SecurityUpdates
-                - Key: MSRC_SEVERITY
-                  Values:
-                    - Critical
-                    - Important
-                    - Moderate
-                    - Low
-                    - Unspecified
-      Description: Service Catalog EC2 Reference Architecture Patch Baseline for Microsoft
-        Windows instace
-      Name: sc-ec2-ra-windows-patch-baseline
-  MaintenanceWindowRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - ec2.amazonaws.com
-                - ssm.amazonaws.com
-            Action:
-              - sts:AssumeRole
-  MaintenanceWindow:
-    Type: AWS::SSM::MaintenanceWindow
-    Properties:
-      Description: Maintenance window to allow for patching windows instances
-      AllowUnassociatedTargets: false
-      Cutoff: 2
-      Schedule: cron(* 17 * * ? *)
-      Duration: 6
-      Name: sc-ec2-ra-windows-maintenance-window
-  WindowsMainteanceWindowTarget:
-    Type: AWS::SSM::MaintenanceWindowTarget
-    Properties:
-      OwnerInformation: Service Catalog EC2 Reference Architecture
-      Description: Service Catalog EC2 Reference Architecture Maintenance Window for
-        Microsoft Windows Instances
-      WindowId: !Ref 'MaintenanceWindow'
-      ResourceType: INSTANCE
-      Targets:
-        - Key: InstanceIds
-          Values:
-            - !Ref 'WindowsInstance'
-      Name: sc-ec2-ra-windows-patch-targets
-  WindowsMaintenanceWindowTaskScan:
-    Type: AWS::SSM::MaintenanceWindowTask
-    Properties:
-      MaxErrors: 1
-      Description: 'Service Catalog EC2 Reference Architecture Maintenance Window
-        Task: Scan for update for Microsoft Windows Instance'
-      ServiceRoleArn: !GetAtt 'MaintenanceWindowRole.Arn'
-      Priority: 1
-      MaxConcurrency: 1
-      Targets:
-        - Key: InstanceIds
-          Values:
-            - !Ref 'WindowsInstance'
-      Name: patch-sc-ec2-ra-windows-instances
-      TaskArn: AWS-RunPatchBaseline
-      WindowId: !Ref 'MaintenanceWindow'
-      TaskParameters:
-        Operation:
-          Values:
-            - Scan
-      TaskType: RUN_COMMAND
-  WindowsMaintenanceWindowTask:
-    Type: AWS::SSM::MaintenanceWindowTask
-    Properties:
-      MaxErrors: 1
-      Description: 'Service Catalog EC2 Reference Architecture Maintenance Window
-        Task: Install update for Microsoft Windows Instance'
-      ServiceRoleArn: !GetAtt 'MaintenanceWindowRole.Arn'
-      Priority: 2
-      MaxConcurrency: 1
-      Targets:
-        - Key: InstanceIds
-          Values:
-            - !Ref 'WindowsInstance'
-      Name: patch-sc-ec2-ra-windows-instances
-      TaskArn: AWS-RunPatchBaseline
-      WindowId: !Ref 'MaintenanceWindow'
-      TaskParameters:
-        Operation:
-          Values:
-            - Install
-      TaskType: RUN_COMMAND
 Outputs:
   TemplateID:
     Value: service-catalog-reference-architectures/sc-ec2-ra
@@ -338,11 +231,7 @@ Outputs:
     Value: !Ref 'KeyPair'
   WindowsInstanceType:
     Value: !Ref 'WindowsInstanceType'
-  IAMInstancePatchingRole:
-    Value: !Ref 'InstancePatchingRole'
-  IAMPatchingInstanceProfile:
-    Value: !Ref 'PatchingInstanceProfile'
-  SSMMaintenaceWindowRole:
-    Value: !Ref 'MaintenanceWindowRole'
-  SSMWindowsPatchBaseline:
-    Value: !Ref 'WindowsPatchBaseline'
+  IAMInstanceRole:
+    Value: !Ref 'InstanceRole'
+  IAMInstanceProfile:
+    Value: !Ref 'InstanceProfile'


### PR DESCRIPTION
- Remove too-permissive ssm policies from InstanceRole
- Remove all patching resources. Patching will be re-added when IT can come up with a strategy for this -- it is outside the scope of Service Catalog development.

These are the same changes as applied to the linux jumpcloud template yesterday.