### PR TITLE
Attempt to fix s3 synapse bucket provisioning

### DIFF
--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -76,6 +76,7 @@ Resources:
   # https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro
   SynapseOwnerFile:
     Type: AWS::S3::Object
+    DependsOn: S3Bucket
     Metadata:
       cfn-lint:
         config:


### PR DESCRIPTION
Seeing the following error when provisioning an S3 synapse bucket:

"errorCode":"ValidationException","errorMessage":"Processed template of
Stack SC-237179673806-pp-pdfndguyqnu3k is not ready. Specify Original to
get user-submitted template

My hypothesis is that the SynapseOwnerFile resource is attempting to
create a file however the bucket has not been created yet.
We add a DependsOn to make the file dependent on the bucket.