### PR TITLE
Fix S3 synapse bucket provisioning

### DIFF
--- a/iam/sc-s3-launchrole.yaml
+++ b/iam/sc-s3-launchrole.yaml
@@ -6,6 +6,7 @@ Resources:
       RoleName: SCS3LaunchRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AWSLambdaFullAccess
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/iam/sc-s3-launchrole.yaml
+++ b/iam/sc-s3-launchrole.yaml
@@ -6,7 +6,7 @@ Resources:
       RoleName: SCS3LaunchRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/AWSLambdaFullAccess
+        - arn:aws:iam::aws:policy/AWSLambdaRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
Our Synapse S3 bucket template contains a macro (lambda).  When provisioning
the template thru the SC it failed to execute the lambda because it didn't have
permissions.  It would fail with the following (not helpful) message:

  Failed to execute transform 237179673806::S3Objects. Rollback requested by user.

Setting the permissions in the lambda itself does not work because the service
catalog role will override those permissions.  Fix this by giving the SC role
the full lambda permissions.