### PR TITLE
Revert "Attempt to fix s3 synapse bucket provisioning (#51)"

### DIFF
--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -76,7 +76,6 @@ Resources:
   # https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro
   SynapseOwnerFile:
     Type: AWS::S3::Object
-    DependsOn: S3Bucket
     Metadata:
       cfn-lint:
         config:


### PR DESCRIPTION
This reverts commit e50a34934949a355db892e4d37d70c4fb5aca352.
This change is not neccessary, PR #57 fixes the SC s3 synapse bucket