### PR TITLE
add a bucket URL

### DIFF
--- a/s3/sc-s3-cidr-ra.yaml
+++ b/s3/sc-s3-cidr-ra.yaml
@@ -54,3 +54,5 @@ Outputs:
     Value: !Ref 'S3UserARN'
   BucketARN:
     Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'

--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -78,3 +78,5 @@ Outputs:
     Value: !Ref 'S3Bucket'
   BucketARN:
     Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'

--- a/s3/sc-s3-mfa-ra.yaml
+++ b/s3/sc-s3-mfa-ra.yaml
@@ -46,3 +46,5 @@ Outputs:
     Value: !Ref 'S3UserARN'
   BucketARN:
     Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'

--- a/s3/sc-s3-public-ra.yaml
+++ b/s3/sc-s3-public-ra.yaml
@@ -18,3 +18,5 @@ Outputs:
     Description: Name of the Amazon S3 bucket.
   BucketARN:
     Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -93,3 +93,6 @@ Outputs:
     Value: !Ref 'S3Bucket'
   BucketARN:
     Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'
+

--- a/s3/sc-s3-transition-ra.yaml
+++ b/s3/sc-s3-transition-ra.yaml
@@ -59,3 +59,5 @@ Outputs:
     Value: !Ref 'S3ObjectDeletionDelay'
   BucketARN:
     Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'


### PR DESCRIPTION
SC end users don’t have list bucket permission so they can’t just goto the S3
console and type the bucket name to access their bucket.  However they can acess
the bucket with a direct link.  We provide a direct link in the outputs
to make it easier to navigate to the bucket from the provisioned
products list page.