### PR TITLE
[SC-26] update SC end user permissions

### DIFF
--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -18,6 +18,7 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
+        - !Ref SCEnduserServiceActionPolicy
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
@@ -27,6 +28,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
+        - !Ref SCEnduserServiceActionPolicy
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -49,6 +49,28 @@ Resources:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
             Resource: "*"
+  # Give SC end users permission to start/stop/reboot instances
+  SCEnduserServiceActionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Expand permissions SC users.
+      Path: "/"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - "servicecatalog:ListServiceActionsForProvisioningArtifact"
+              - "servicecatalog:ExecuteprovisionedProductServiceAction"
+              - "ssm:DescribeDocument"
+              - "ssm:GetAutomationExecution"
+              - "ssm:StartAutomationExecution"
+              - "ssm:StopAutomationExecution"
+              - "cloudformation:ListStackResources"
+              - "ec2:DescribeInstanceStatus"
+              - "ec2:StartInstances"
+              - "ec2:StopInstances"
+            Resource: "*"
   CFNDenyGetTemplateSummaryPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:


### PR DESCRIPTION
Add permission to allow SC end users to start/stop/reboot their
instances. Following instrcutions from the AWS docs[1]

[1] https://docs.aws.amazon.com/servicecatalog/latest/adminguide/using-service-actions.html