### PR TITLE
Always use private security group

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -235,7 +235,6 @@ Resources:
         - !Ref 'InstanceRole'
   PrivateSubnetSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
-    Condition: UsePrivateSubnet
     Properties:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
@@ -436,15 +435,15 @@ Resources:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
       SubnetId: !If
-        - UsePrivateSubnet
-        - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+        - UsePublicSubnet
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
       SecurityGroupIds: !If
-        - UsePrivateSubnet
+        - UsePublicSubnet
+        - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]
         - [!Ref PrivateSubnetSecurityGroup]
-        - [!Ref PublicSubnetSecurityGroup]
       KeyName: 'scipool'
       BlockDeviceMappings:
         -

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -191,7 +191,7 @@ Parameters:
     Type: String
   OpenPort:
     Description: (Optional) Port to open if on public network
-    Type: String
+    Type: Number
     Default: 22
   LinuxDistribution:
     Type: String
@@ -253,11 +253,6 @@ Resources:
           ToPort: -1
           IpProtocol: '-1'
   PublicSubnetSecurityGroup:
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-            - E3012
     Type: 'AWS::EC2::SecurityGroup'
     Condition: UsePublicSubnet
     Properties:


### PR DESCRIPTION
- always use private security group
- if public network selected, additionally attach public security group