### PR TITLE
[SC-4] open application ports

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -18,7 +18,7 @@ Metadata:
       PrivateNetwork:
         default: Use private network?
       OpenPort:
-        default: Open Port
+        default: Open Ports (Public Network Only)
       EC2InstanceType:
         default: EC2 Instance Type
       LinuxDistribution:
@@ -190,7 +190,7 @@ Parameters:
     Description: Amazon EC2 Instance Type
     Type: String
   OpenPort:
-    Description: (Optional) Port to open if on public network
+    Description: (Optional) Standard ports to open for applications
     Type: String
     AllowedValues:
       - Web

--- a/ec2/sc-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud.yaml
@@ -191,8 +191,11 @@ Parameters:
     Type: String
   OpenPort:
     Description: (Optional) Port to open if on public network
-    Type: Number
-    Default: 22
+    Type: String
+    AllowedValues:
+      - Web
+      - RStudio
+      - MySql
   LinuxDistribution:
     Type: String
     Description: Linux distribution to use for instance operation system
@@ -210,6 +213,10 @@ Conditions:
   UsePrivateSubnet: !Equals [!Ref PrivateNetwork, 'true']
   UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']
   IsUbuntu: !Equals [!Ref LinuxDistribution, 'Ubuntu']
+  OpenWebPort: !Equals [!Ref OpenPort, 'Web']
+  OpenRStudioPort: !Equals [!Ref OpenPort, 'RStudio']
+  OpenMySqlPort: !Equals [!Ref OpenPort, 'MySql']
+  OpenHTTPSPort: !Or [{"Condition": "OpenWebPort"}, {"Condition": "OpenRStudioPort"}]
 Resources:
   InstanceRole:
     Type: AWS::IAM::Role
@@ -259,12 +266,13 @@ Resources:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
         'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
-      SecurityGroupIngress:
-        - Description: allow SSH
-          IpProtocol: tcp
-          FromPort: !Ref OpenPort
-          ToPort: !Ref OpenPort
-          CidrIp: '0.0.0.0/0'
+      SecurityGroupIngress: [
+        {"Description": "allow SSH", "IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIp": "0.0.0.0/0"},
+        !If [OpenWebPort, {"Description": "allow HTTP", "IpProtocol": "tcp", "FromPort": 80, "ToPort": 80, "CidrIp": "0.0.0.0/0"}, !Ref "AWS::NoValue"],
+        !If [OpenRStudioPort, {"Description": "allow RStudio", "IpProtocol": "tcp", "FromPort": 8787, "ToPort": 8787, "CidrIp": "0.0.0.0/0"}, !Ref "AWS::NoValue"],
+        !If [OpenMySqlPort, {"Description": "allow MySql", "IpProtocol": "tcp", "FromPort": 3306, "ToPort": 3306, "CidrIp": "0.0.0.0/0"}, !Ref "AWS::NoValue"],
+        !If [OpenHTTPSPort, {"Description": "allow HTTPS", "IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "CidrIp": "0.0.0.0/0"}, !Ref "AWS::NoValue"],
+      ]
       SecurityGroupEgress:
         - Description: allow all outgoing
           IpProtocol: '-1'


### PR DESCRIPTION
Allow SC users to open ports by selecting an application that will run
on the instance. The idea is to set ingress rules based on default ports
required by certain applications.  Deviating from the default application
ports would be a more custom setup which may require using the scicomp
provisioner