### PR TITLE
[SC-13] Include support info

### DIFF
--- a/ec2/sc-product-ec2-demowebserver.yaml
+++ b/ec2/sc-product-ec2-demowebserver.yaml
@@ -41,7 +41,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-demowebserver.yaml
+++ b/ec2/sc-product-ec2-demowebserver.yaml
@@ -19,15 +19,16 @@ Parameters:
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Demo Linux Webserver
       Description: This product builds a webserver (Apache or NGINX) EC2 instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: NGINX webserver
           Info:
@@ -37,6 +38,10 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-apache-nokey.yaml'
           Name: !Sub 'Apache ${ProductVersionName}'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -19,6 +19,11 @@ Parameters:
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: EC2 Linux with Jumpcloud Integration
       Description: This product builds one Linux EC2 instance, either
@@ -27,15 +32,15 @@ Resources:
         and install operating system updates on the EC2 instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Sage IT
-      SupportEmail: it@sagebase.org
-      AcceptLanguage: en
-      SupportUrl: https://app.slack.com/client/T092YT0LV/CEFQD0KU1
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud.yaml
@@ -40,7 +40,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux.yaml
+++ b/ec2/sc-product-ec2-linux.yaml
@@ -39,7 +39,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-linux.yaml
+++ b/ec2/sc-product-ec2-linux.yaml
@@ -19,6 +19,11 @@ Parameters:
 Resources:
   scec2linuxproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon Elastic Compute Cloud (EC2) Linux
       Description: This product builds one Amazon Linux EC2 instance and create a
@@ -26,15 +31,15 @@ Resources:
         operating system updates the EC2 instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Sage IT
-      SupportEmail: it@sagebase.org
-      AcceptLanguage: en
-      SupportUrl: https://app.slack.com/client/T092YT0LV/CEFQD0KU1
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2linux:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-webserver.yaml
+++ b/ec2/sc-product-ec2-webserver.yaml
@@ -42,7 +42,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-webserver.yaml
+++ b/ec2/sc-product-ec2-webserver.yaml
@@ -19,16 +19,17 @@ Parameters:
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon Elastic Compute Cloud (EC2) Linux Webserver
       Description: This product builds one Amazon Linux EC2 webserver (Apache or NGINX)
         instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: NGINX webserver
           Info:
@@ -38,6 +39,10 @@ Resources:
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-apache.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -19,6 +19,11 @@ Parameters:
 Resources:
   scec2windowsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: EC2 Windows with Jumpcloud Integration
       Description: This product builds one Microsoft Windows EC2 instance with
@@ -27,15 +32,15 @@ Resources:
         on the EC2 instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Sage IT
-      SupportEmail: it@sagebase.org
-      AcceptLanguage: en
-      SupportUrl: https://app.slack.com/client/T092YT0LV/CEFQD0KU1
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-jumpcloud.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows-jumpcloud.yaml
+++ b/ec2/sc-product-ec2-windows-jumpcloud.yaml
@@ -40,7 +40,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows.yaml
+++ b/ec2/sc-product-ec2-windows.yaml
@@ -19,6 +19,11 @@ Parameters:
 Resources:
   scec2windowsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon Elastic Compute Cloud (EC2) Windows
       Description: This product builds one Microsoft Windows EC2 instance and create
@@ -26,15 +31,15 @@ Resources:
         operating system updates on the EC2 instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Sage IT
-      SupportEmail: it@sagebase.org
-      AcceptLanguage: en
-      SupportUrl: https://app.slack.com/client/T092YT0LV/CEFQD0KU1
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-windows-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ec2/sc-product-ec2-windows.yaml
+++ b/ec2/sc-product-ec2-windows.yaml
@@ -39,7 +39,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateec2windows:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-container-pipeline.yaml
+++ b/ecs/sc-product-container-pipeline.yaml
@@ -37,7 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-container-pipeline.yaml
+++ b/ecs/sc-product-container-pipeline.yaml
@@ -19,20 +19,25 @@ Parameters:
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Container Codepipeline project
       Description: This product builds a codepipeline project for container CI/CD.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: CodePipeline project
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/container-codepipeline-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatecluster.yaml
+++ b/ecs/sc-product-fargatecluster.yaml
@@ -19,20 +19,25 @@ Parameters:
 Resources:
   WebserverProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: ECS Fargate Cluster
       Description: This product builds an ECS cluster for Fargate.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: Fargate Cluster
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/fargate-private-vpc.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatecluster.yaml
+++ b/ecs/sc-product-fargatecluster.yaml
@@ -37,7 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatetask.yaml
+++ b/ecs/sc-product-fargatetask.yaml
@@ -37,7 +37,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/ecs/sc-product-fargatetask.yaml
+++ b/ecs/sc-product-fargatetask.yaml
@@ -19,20 +19,25 @@ Parameters:
 Resources:
   ECSTaskProduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon ECS task
       Description: This product creates a simple ECS task for Fargate.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: Fargate Task
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}ecs/fargate-task.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatenginxcf:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/emr/sc-product-emr.yaml
+++ b/emr/sc-product-emr.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scemrproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon Elastic MapReduce (EMR)
       Description: This product builds an Amazon Elastic MapReduce cluster with 1
         master nodes and 2 core nodes.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}emr/sc-emr-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateemr:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/emr/sc-product-emr.yaml
+++ b/emr/sc-product-emr.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateemr:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/emr/sc-product-emrsparkhbase.yaml
+++ b/emr/sc-product-emrsparkhbase.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scemrproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: EMR cluster for Spark or S3 backed Hbase
       Description: This product builds an Amazon Elastic MapReduce cluster for Spark
         or S3 backed Hbase best practices.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}emr/sc-emr-SparkHbase.yaml'
           Name: !Ref ProductVersionName
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateemr:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/emr/sc-product-emrsparkhbase.yaml
+++ b/emr/sc-product-emrsparkhbase.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateemr:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/glue/sc-product-glue.yaml
+++ b/glue/sc-product-glue.yaml
@@ -16,20 +16,25 @@ Parameters:
 Resources:
   scglueproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: AWS Glue crawler
       Description: This product creates a glue crawler.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}glue/sc-glue-ra.yaml'
           Name: v1.1
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associateglue:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/glue/sc-product-glue.yaml
+++ b/glue/sc-product-glue.yaml
@@ -34,7 +34,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associateglue:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/labs/end-to-end-it-lifecycle-management/cfn/SC_ConnectorForServiceNowv2.0.2-AWS_Configurations.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/SC_ConnectorForServiceNowv2.0.2-AWS_Configurations.yaml
@@ -55,7 +55,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   ExecutionRole:
     Type: AWS::IAM::Role
     Condition: CreateStackSetResources

--- a/labs/end-to-end-it-lifecycle-management/cfn/SC_ConnectorForServiceNowv2.0.2-AWS_Configurations.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/SC_ConnectorForServiceNowv2.0.2-AWS_Configurations.yaml
@@ -36,21 +36,26 @@ Resources:
   
   S3Product:
     Type: "AWS::ServiceCatalog::CloudFormationProduct"
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       AcceptLanguage: "en"
       Description: "S3 Product"
       Distributor: "CCOE"
       Name: "S3 WithLifeCycle"
       Owner: "CCOE"
-      SupportEmail: "email@mycompany.com"
-      SupportUrl: "https://www.mycompany.com"
-      SupportDescription: "This is a sample S3 product For SNOW-SC POC."
       ProvisioningArtifactParameters:
         - Description: "Version 3 of S3 product"
           Name: "Version - 3.0"
           Info:
             LoadTemplateFromURL : "https://raw.githubusercontent.com/aws-samples/aws-service-catalog-terraform-reference-architecture/master/ServiceCatalogSamples/sc-s3-transition-snow-ra.json"
-  
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   ExecutionRole:
     Type: AWS::IAM::Role
     Condition: CreateStackSetResources

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
@@ -127,7 +127,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab.yaml
@@ -109,20 +109,25 @@ Resources:
       PrincipalType: IAM
   ProdEC2:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Owner: MP Team
       SupportDescription: Support Description
       Description: EC2 This product launches a linux server.
-      Distributor: AWS MP Team
-      SupportEmail: awsmp@example.com
-      AcceptLanguage: en
-      SupportUrl: https://support.com
       Name: !Sub 'EC2 Instance'
       ProvisioningArtifactParameters:
         - Description: Base Version
           Info:
             LoadTemplateFromURL: https://s3.amazonaws.com/marketplace-sa-resources/ec2CFT.json
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
@@ -96,20 +96,25 @@ Resources:
       PrincipalType: IAM
   ProdEC2:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Owner: MP Team
-      SupportDescription: Support Description
       Description: EC2 This product launches a linux server.
       Distributor: AWS MP Team
-      SupportEmail: awsmp@example.com
-      AcceptLanguage: en
-      SupportUrl: https://support.com
       Name: !Sub 'EC2 Instance'
       ProvisioningArtifactParameters:
         - Description: Base Version
           Info:
             LoadTemplateFromURL: https://s3.amazonaws.com/marketplace-sa-resources/ec2CFT.json
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
+++ b/labs/end-to-end-it-lifecycle-management/cfn/lab_v2.yaml
@@ -114,7 +114,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   ProdAssEC2:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     DependsOn:

--- a/rds/sc-product-rds-mariadb.yaml
+++ b/rds/sc-product-rds-mariadb.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mariadb.yaml
+++ b/rds/sc-product-rds-mariadb.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon RDS MariaDB Database
       Description: This product builds an Amazon AWS RDS MariaDB master database instance
         with options for a single instance or multi-az instances.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mariadb-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mssql.yaml
+++ b/rds/sc-product-rds-mssql.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mssql.yaml
+++ b/rds/sc-product-rds-mssql.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon RDS Microsoft SQL Database
       Description: This product builds an Amazon AWS RDS Microsoft SQL master database
         instance with options for a single instance or multi-az instances.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mssql-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mysql.yaml
+++ b/rds/sc-product-rds-mysql.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-mysql.yaml
+++ b/rds/sc-product-rds-mysql.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon RDS MySQL Database
       Description: This product builds an Amazon AWS RDS MySQL master database instance
         with options for a single instance or multi-az instances.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-mysql-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-postgresql.yaml
+++ b/rds/sc-product-rds-postgresql.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/rds/sc-product-rds-postgresql.yaml
+++ b/rds/sc-product-rds-postgresql.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scrdsproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon RDS PostgreSQL Database
       Description: This product builds an Amazon AWS RDS PostgreSQL master database
         instance with options for a single instance or multi-az instances.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}rds/sc-rds-postgresql-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associaterds:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: S3 Private Encrypted Bucket
       Description: This product builds an AWS S3 bucket encrypted with private
         access accessible from any source.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-mfa.yaml
+++ b/s3/sc-product-s3-private-mfa.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-mfa.yaml
+++ b/s3/sc-product-s3-private-mfa.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon S3 Private Bucket with MFA Delete Restrictions
       Description: This product builds an Amazon AWS S3 bucket with multi-factor authentication
         restricted bucket delete option.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-mfa-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-trans.yaml
+++ b/s3/sc-product-s3-private-trans.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private-trans.yaml
+++ b/s3/sc-product-s3-private-trans.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon S3 Private Bucket with Transition Ruleset
       Description: This product builds an Amazon AWS S3 bucket with a transition ruleset
         to S3-IA and Glacier.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-transition-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private.yaml
+++ b/s3/sc-product-s3-private.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-private.yaml
+++ b/s3/sc-product-s3-private.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon S3 Private Bucket with CIDR Restricted Access
       Description: This product builds an Amazon AWS S3 bucket with private access
         accessible from a restricted soure.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-cidr-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-public.yaml
+++ b/s3/sc-product-s3-public.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon S3 Public Bucket with Read Only Access
       Description: This product builds an Amazon AWS S3 bucket with options for read
         only bucket with public access from any source.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-public-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-public.yaml
+++ b/s3/sc-product-s3-public.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -19,21 +19,26 @@ Parameters:
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: S3 Synapse Bucket
       Description: This product builds an AWS S3 bucket with private access
         for Synapse.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associates3:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/serverless/sc-product-serverless-lambda.yaml
+++ b/serverless/sc-product-serverless-lambda.yaml
@@ -38,7 +38,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatelambda:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/serverless/sc-product-serverless-lambda.yaml
+++ b/serverless/sc-product-serverless-lambda.yaml
@@ -17,6 +17,11 @@ Parameters:
 Resources:
   lambdaproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon Lambda APIGateway Endpoint
       Description: This product builds one Amazon Lambda function and APIGateway endpoint
@@ -24,16 +29,16 @@ Resources:
         Ref: PortfolioProvider
       Distributor:
         Ref: PortfolioProvider
-      SupportDescription: Operations Team
-      SupportEmail: support@yourcompany.com
-      AcceptLanguage: en
-      SupportUrl: http://helpdesk.yourcompany.com
       ProvisioningArtifactParameters:
       - Description: baseline version
         Info:
           LoadTemplateFromURL:
             Fn::Sub: "${RepoRootURL}serverless/sc-serverless-lambda.yaml"
         Name: v1.2
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatelambda:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/vpc/sc-product-vpc.yaml
+++ b/vpc/sc-product-vpc.yaml
@@ -19,6 +19,11 @@ Parameters:
 Resources:
   scvpcproduct:
     Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Name: Amazon Virtual Private Cloud (VPC)
       Description: This product builds a multi-availability zone Amazon AWS Virtual
@@ -26,15 +31,15 @@ Resources:
         bastion instance.
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
-      SupportDescription: Sage IT
-      SupportEmail: it@sagebase.org
-      AcceptLanguage: en
-      SupportUrl: https://app.slack.com/client/T092YT0LV/CEFQD0KU1
       ProvisioningArtifactParameters:
         - Description: baseline version
           Info:
             LoadTemplateFromURL: !Sub '${RepoRootURL}vpc/sc-vpc-ra.yaml'
           Name: !Ref 'ProductVersionName'
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
   Associatevpc:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:

--- a/vpc/sc-product-vpc.yaml
+++ b/vpc/sc-product-vpc.yaml
@@ -39,7 +39,7 @@ Resources:
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:
-          Location : "s3://CloudformationSnippetsBucket/scipoolprod-sc-lib-infra/support.yaml"
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
   Associatevpc:
     Type: AWS::ServiceCatalog::PortfolioProductAssociation
     Properties:


### PR DESCRIPTION
Include the support snippet info from an external file.
This depends on PR https://github.com/Sage-Bionetworks/admincentral-infra/pull/77

Note from [AWS::Include docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)

```
If your snippets change, your stack doesn't automatically pick up those changes.
To get those changes, you must update the stack with the updated snippets.
If you update your stack, make sure your included snippets haven't changed
without your knowledge. To verify before updating the stack, check the change set.
```