### PR TITLE
SC-16 Add StackDatetime and allow product-level version in S3 portfolio stack

### DIFF
--- a/s3/sc-portfolio-s3-basic-development.yaml
+++ b/s3/sc-portfolio-s3-basic-development.yaml
@@ -62,9 +62,10 @@ Parameters:
     Type: String
     Description: Root url for the repo containing the product templates.
     Default: https://s3.amazonaws.com/aws-service-catalog-reference-architectures/
-  ProductVersionName:
+  StackDatetime:
     Type: String
-    Description: The product version name in the service catalog
+    Description: Last updated date and time of portfolio
+    Default: ''
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'

--- a/s3/sc-portfolio-s3-basic.yaml
+++ b/s3/sc-portfolio-s3-basic.yaml
@@ -62,9 +62,10 @@ Parameters:
     Type: String
     Description: Root url for the repo containing the product templates.
     Default: https://s3.amazonaws.com/aws-service-catalog-reference-architectures/
-  ProductVersionName:
+  StackDatetime:
     Type: String
-    Description: The product version name in the service catalog
+    Description: Last updated date and time of portfolio
+    Default: ''
 Conditions:
   CreateLaunchConstraint: !Equals
     - !Ref 'LaunchRoleName'
@@ -137,7 +138,7 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersionName: !Ref 'ProductVersionName'
+        StackDatetime: !Ref StackDatetime
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-private-enc.yaml'
       TimeoutInMinutes: 5
   s3synapseproduct:
@@ -151,6 +152,6 @@ Resources:
           - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
         PortfolioId: !Ref 'SCS3portfolio'
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersionName: !Ref 'ProductVersionName'
+        StackDatetime: !Ref StackDatetime
       TemplateURL: !Sub '${RepoRootURL}s3/sc-product-s3-synapse.yaml'
       TimeoutInMinutes: 5

--- a/s3/sc-product-s3-private-enc.yaml
+++ b/s3/sc-product-s3-private-enc.yaml
@@ -13,9 +13,10 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersionName:
+  StackDatetime:
     Type: String
-    Description: The product version name in the service catalog
+    Description: Last updated date and time of portfolio
+    Default: ''
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -31,10 +32,10 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: baseline version
+        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra.yaml'
-          Name: !Ref 'ProductVersionName'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-encrypted-ra-v1.0.0.yaml'
+          Name: v1.0.0
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/s3/sc-product-s3-synapse.yaml
+++ b/s3/sc-product-s3-synapse.yaml
@@ -13,9 +13,10 @@ Parameters:
   RepoRootURL:
     Type: String
     Description: Root url for the repo containing the product templates.
-  ProductVersionName:
+  StackDatetime:
     Type: String
-    Description: The product version name in the service catalog
+    Description: Last updated date and time of portfolio
+    Default: ''
 Resources:
   scs3product:
     Type: AWS::ServiceCatalog::CloudFormationProduct
@@ -31,10 +32,10 @@ Resources:
       Owner: !Ref 'PortfolioProvider'
       Distributor: !Ref 'PortfolioProvider'
       ProvisioningArtifactParameters:
-        - Description: baseline version
+        - Description: !Sub 'Baseline version. Last portfolio update occurred at ${StackDatetime}.'
           Info:
-            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra.yaml'
-          Name: !Ref 'ProductVersionName'
+            LoadTemplateFromURL: !Sub '${RepoRootURL}s3/sc-s3-synapse-ra-v1.0.0.yaml'
+          Name: v1.0.0
       'Fn::Transform':
         Name: 'AWS::Include'
         Parameters:

--- a/templates/taskcat-verify-all.yaml
+++ b/templates/taskcat-verify-all.yaml
@@ -102,6 +102,5 @@ Resources:
         LaunchRoleName: ''
         PrincipalRoleName1: ''
         RepoRootURL: !Ref 'RepoRootURL'
-        ProductVersionName: !Ref 'ProductVersionName'
       TemplateURL: !Sub '${RepoRootURL}s3/sc-portfolio-s3-basic.yaml'
       TimeoutInMinutes: 5


### PR DESCRIPTION
This performs similar changes to S3 portfolios as made to the EC2 portfolios in https://github.com/Sage-Bionetworks/scipoolprod-sc-lib-infra/pull/78.
