### PR TITLE
SC-29 tag linux instance with name used for provisioned product

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -227,6 +227,8 @@ Resources:
       ManagedPolicyArns:
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -295,8 +297,9 @@ Resources:
           SetupJumpcloud:
             - install_jc
             - config_jc
-          SetupVolume:
+          SetTags:
             - TagRootVolume
+            - TagInstance
         cfn_hup_service:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -314,7 +317,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetupVolume --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
               mode: "000400"
               owner: root
               group: root
@@ -371,6 +374,7 @@ Resources:
 
                 echo "export AWS_REGION=$AWS_REGION" > /opt/sage/bin/instance_env_vars.sh
                 echo "export STACK_NAME=$STACK_NAME" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export STACK_ID=$STACK_ID" >> /opt/sage/bin/instance_env_vars.sh
                 echo "export EC2_INSTANCE_ID=$EC2_INSTANCE_ID" >> /opt/sage/bin/instance_env_vars.sh
                 echo "export ROOT_DISK_ID='$ROOT_DISK_ID'" >> /opt/sage/bin/instance_env_vars.sh
                 echo "export DEPARTMENT=$DEPARTMENT" >> /opt/sage/bin/instance_env_vars.sh
@@ -387,6 +391,7 @@ Resources:
               env:
                 AWS_REGION: !Ref AWS::Region
                 STACK_NAME: !Ref AWS::StackName
+                STACK_ID: !Ref AWS::StackId
         install_jc:
           commands:
             01_jumpcloud_agent:
@@ -436,6 +441,35 @@ Resources:
                   - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
                   - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
                   - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+        TagInstance:
+          files:
+            /opt/sage/bin/apply_name_tag.sh:
+              content: |
+                #! /bin/bash
+
+                set -xe
+
+                source /opt/sage/bin/instance_env_vars.sh
+                RESOURCE_ID=${STACK_ID##*/}
+                PRODUCTS=$(/usr/bin/aws --region $AWS_REGION \
+                  servicecatalog search-provisioned-products \
+                  --filters SearchQuery=$RESOURCE_ID )
+                NUM_PRODUCTS=$(echo $PRODUCTS | jq '.TotalResultsCount')
+                if ["$NUM_PRODUCTS" -ne 1]
+                then
+                  echo "ERROR: there are $NUM_PRODUCTS provisioned products, cannot isolate a name for tagging."
+                  exit 1
+                fi
+                NAME=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].Name')
+                /usr/bin/aws ec2 create-tags --region $AWS_REGION \
+                  --resources $EC2_INSTANCE_ID \
+                  --tags Key=Name,Value=$NAME
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_name_tag:
+              command: "/opt/sage/bin/apply_name_tag.sh"
     Properties:
       ImageId: !FindInMap [LinuxDistributions, !Ref LinuxDistribution, AMIID]
       InstanceType: !Ref 'EC2InstanceType'
@@ -471,7 +505,7 @@ Resources:
           else
             /bin/yum update -y aws-cfn-bootstrap
           fi
-          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetupVolume --region ${AWS::Region}
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
       Tags:
         - Key: Name


### PR DESCRIPTION
This adds a cfn-init script for tagging `Name` of a linux instance provisioned through Service Catalog, by looking up the name used for the provisioned product and using that for the tag value.

This PR depends upon https://github.com/Sage-Bionetworks/scipoolprod-infra/pull/67.
