### PR TITLE
[SC-27] Provide SC users with connection info

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -533,3 +533,5 @@ Outputs:
     Value: !Ref 'InstanceRole'
   IAMInstanceProfile:
     Value: !Ref 'InstanceProfile'
+  ConnectionInstructions:
+    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -281,3 +281,5 @@ Outputs:
     Value: !Ref 'InstanceRole'
   IAMInstanceProfile:
     Value: !Ref 'InstanceProfile'
+  ConnectionInstructions:
+    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"


### PR DESCRIPTION
Since SC users are given a dashboard of info after provisioning
SC products, the "provisioned products" list, the idea in this PR
is to use that dashboard to provide additional additional info
to users.  In this specific case we are providing info on how
to connected to a provisioned instance.