### PR TITLE
Use different directories for volume depending upon linux os chosen

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -486,7 +486,7 @@ Resources:
       KeyName: 'scipool'
       BlockDeviceMappings:
         -
-          DeviceName: "/dev/sda1"
+          DeviceName: !If [IsUbuntu, "/dev/sda1", "/dev/xvda"]
           Ebs:
             DeleteOnTermination: true
             VolumeSize: !Ref VolumeSize


### PR DESCRIPTION
This PR handles volumes differently depending on whether the distribution is Amazon Linux or Ubuntu. See [JIRA SC-47](https://sagebionetworks.jira.com/browse/SC-47).

The way @zaro0508 wrote SC-47, it sounds like the minimum `VolumeSize` should be different. However, there is no difference in minimum volume size between the two distros, only in `DeviceName`.