### PR TITLE
Add development notebook product

### DIFF
--- a/dev-deploy-templates.sh
+++ b/dev-deploy-templates.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script can be used while doing development
+# List only the development files you're working on
+# Those are uploaded to the S3 bucket where templates are stored
+# Then, you sceptre to update the relevant development portfolio in scipoolprod-infra
+
+set -ex
+
+S3_BUCKET_URL=s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/scipoolprod-sc-lib-infra/master/
+
+# list the templates you're testing
+templates=(
+  ec2/sc-portfolio-ec2-development.yaml
+  ec2/sc-product-ec2-linux-jumpcloud-notebook-development.yaml
+  ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
+)
+
+for template in "${templates[@]}"
+do
+  aws --profile admincentral-cfservice s3 cp $template $S3_BUCKET_URL$template
+done

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -1,0 +1,500 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Service Catalog: EC2 Reference Architecture.'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Linux Instance Configuration
+        Parameters:
+          - EC2InstanceType
+          - LinuxDistribution
+          - VolumeSize
+          - PrivateNetwork
+    ParameterLabels:
+      EC2InstanceType:
+        default: EC2 Instance Type
+      NotebookType:
+        default: Notebook Type
+      VolumeSize:
+        default: Disk Size
+      PrivateNetwork:
+        default: Use private network?
+Mappings:
+  NotebookTypes:
+    Rstudio:
+      AMIID: ami-036688a77595e31cf
+Parameters:
+  PrivateNetwork:
+    Type: String
+    Description: In the private subnet (recommended) as opposed to a public subnet
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  EC2InstanceType:
+    AllowedValues:
+      - c4.large
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.12xlarge
+      - c5.18xlarge
+      - c5.24xlarge
+      - c5d.large
+      - c5d.xlarge
+      - c5d.2xlarge
+      - c5d.4xlarge
+      - c5d.9xlarge
+      - c5d.12xlarge
+      - c5d.18xlarge
+      - c5d.24xlarge
+      - c5n.large
+      - c5n.xlarge
+      - c5n.2xlarge
+      - c5n.4xlarge
+      - c5n.9xlarge
+      - c5n.18xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.8xlarge
+      - m5.12xlarge
+      - m5.16xlarge
+      - m5.24xlarge
+      - m5a.large
+      - m5a.xlarge
+      - m5a.2xlarge
+      - m5a.4xlarge
+      - m5a.8xlarge
+      - m5a.12xlarge
+      - m5a.16xlarge
+      - m5a.24xlarge
+      - m5ad.large
+      - m5ad.xlarge
+      - m5ad.2xlarge
+      - m5ad.4xlarge
+      - m5ad.12xlarge
+      - m5ad.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.8xlarge
+      - m5d.12xlarge
+      - m5d.16xlarge
+      - m5d.24xlarge
+      - m5dn.large
+      - m5dn.xlarge
+      - m5dn.2xlarge
+      - m5dn.4xlarge
+      - m5dn.8xlarge
+      - m5dn.12xlarge
+      - m5dn.16xlarge
+      - m5dn.24xlarge
+      - m5n.large
+      - m5n.xlarge
+      - m5n.2xlarge
+      - m5n.4xlarge
+      - m5n.8xlarge
+      - m5n.12xlarge
+      - m5n.16xlarge
+      - m5n.24xlarge
+      - r4.large
+      - r4.xlarge
+      - r4.2xlarge
+      - r4.4xlarge
+      - r4.8xlarge
+      - r4.16xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.8xlarge
+      - r5.12xlarge
+      - r5.16xlarge
+      - r5.24xlarge
+      - r5a.large
+      - r5a.xlarge
+      - r5a.2xlarge
+      - r5a.4xlarge
+      - r5a.8xlarge
+      - r5a.12xlarge
+      - r5a.16xlarge
+      - r5a.24xlarge
+      - r5ad.large
+      - r5ad.xlarge
+      - r5ad.2xlarge
+      - r5ad.4xlarge
+      - r5ad.12xlarge
+      - r5ad.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.8xlarge
+      - r5d.12xlarge
+      - r5d.16xlarge
+      - r5d.24xlarge
+      - r5dn.large
+      - r5dn.xlarge
+      - r5dn.2xlarge
+      - r5dn.4xlarge
+      - r5dn.8xlarge
+      - r5dn.12xlarge
+      - r5dn.16xlarge
+      - r5dn.24xlarge
+      - r5n.large
+      - r5n.xlarge
+      - r5n.2xlarge
+      - r5n.4xlarge
+      - r5n.8xlarge
+      - r5n.12xlarge
+      - r5n.16xlarge
+      - r5n.24xlarge
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.nano
+      - t3a.micro
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+    Default: t3.micro
+    Description: Amazon EC2 Instance Type
+    Type: String
+  NotebookType:
+    Type: String
+    Description: Type of notebook software to install
+    Default: Rstudio
+    AllowedValues:
+      - Rstudio
+  VolumeSize:
+    Description: The EC2 volume size (in GB)
+    Type: Number
+    Default: 8
+    MinValue: 8
+    MaxValue: 2000
+Conditions:
+  UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']
+Resources:
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      ManagedPolicyArns:
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+        - !Ref 'InstanceRole'
+  PrivateSubnetSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: >-
+        Allow all traffic to an instance originating from the VPN
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+      SecurityGroupIngress:
+        - CidrIp: !ImportValue
+            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: '-1'
+          Description: 'Allow all VPN traffic'
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: '-1'
+  PublicSubnetSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Condition: UsePublicSubnet
+    Properties:
+      GroupDescription: Allow SSH to port 22
+      VpcId: !ImportValue
+        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+      SecurityGroupIngress:
+        - Description: 'allow SSH'
+          IpProtocol: 'tcp'
+          FromPort: 22
+          ToPort: 22
+          CidrIp: '0.0.0.0/0'
+      SecurityGroupEgress:
+        - Description: 'allow all outgoing'
+          IpProtocol: '-1'
+          CidrIp: '0.0.0.0/0'
+  LinuxInstance:
+    Type: AWS::EC2::Instance
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E1022
+      'AWS::CloudFormation::Init':
+        configSets:
+          SetupCfn:
+            - cfn_hup_service
+          SetEnv:
+            - set_env_vars
+          SetupJumpcloud:
+            - install_jc
+            - config_jc
+          SetTags:
+            - TagRootVolume
+            - TagInstance
+        cfn_hup_service:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+                verbose=true
+                interval=5
+              mode: "000400"
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.LinuxInstance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
+              mode: "000400"
+              owner: root
+              group: root
+            /lib/systemd/system/cfn-hup.service:
+              content: |
+                [Unit]
+                Description=cfn-hup daemon
+
+                [Service]
+                Type=simple
+                ExecStart=/opt/aws/bin/cfn-hup
+                Restart=always
+
+                [Install]
+                WantedBy=multi-user.target
+              mode: "000400"
+              owner: root
+              group: root
+          commands:
+            01_enable_cfn-hup:
+              command: "/bin/systemctl enable cfn-hup.service"
+            02_start_cfn-hup:
+              command: "/bin/systemctl start cfn-hup.service"
+        set_env_vars:
+          packages:
+            apt:
+              awscli: []
+              jq: []
+          files:
+            /opt/sage/bin/make_env_vars_file.sh:
+              content: !Sub |
+                #! /bin/bash
+
+                EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)
+                ROOT_DISK_ID=$(/usr/bin/aws ec2 describe-volumes \
+                  --region $AWS_REGION \
+                  --filters Name=attachment.instance-id,Values=$EC2_INSTANCE_ID \
+                  --query Volumes[].VolumeId --out text)
+                EC2_INSTANCE_TAGS=$(aws --region $AWS_REGION \
+                  ec2 describe-tags \
+                  --filters Name=resource-id,Values=$EC2_INSTANCE_ID)
+                extract_tag_value() {
+                  echo $EC2_INSTANCE_TAGS | jq -j --arg KEYNAME "$1" '.Tags[] | select(.Key == $KEYNAME).Value '
+                }
+                DEPARTMENT=$(extract_tag_value Department)
+                PROJECT=$(extract_tag_value Project)
+                OWNER_EMAIL=$(extract_tag_value OwnerEmail)
+
+                echo "export AWS_REGION=$AWS_REGION" > /opt/sage/bin/instance_env_vars.sh
+                echo "export STACK_NAME=$STACK_NAME" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export STACK_ID=$STACK_ID" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export EC2_INSTANCE_ID=$EC2_INSTANCE_ID" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export ROOT_DISK_ID='$ROOT_DISK_ID'" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export DEPARTMENT=$DEPARTMENT" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export PROJECT=$PROJECT" >> /opt/sage/bin/instance_env_vars.sh
+                echo "export OWNER_EMAIL=$OWNER_EMAIL" >> /opt/sage/bin/instance_env_vars.sh
+                chmod +x /opt/sage/bin/instance_env_vars.sh
+
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_make_env_vars_file:
+              command: ". /opt/sage/bin/make_env_vars_file.sh"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                STACK_ID: !Ref AWS::StackId
+        install_jc:
+          commands:
+            01_jumpcloud_agent:
+              command: !Join
+                - ''
+                - - "/usr/bin/curl --silent --show-error --header 'x-connect-key: "
+                  - Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcConnectKey"}}
+                  - "' https://kickstart.jumpcloud.com/Kickstart | sudo bash"
+        config_jc:
+          files:
+            /opt/sage/bin/associate_jc_systems.sh:
+              content: !Sub |
+                #! /bin/bash
+
+                source /opt/sage/bin/instance_env_vars.sh
+                JC_SYSTEM_ID=$(sudo cat /opt/jc/jcagent.conf|jq -r '.systemKey')
+                JC_SYSTEM_USERS=$(/usr/bin/curl --silent --show-error -X GET \
+                  https://console.jumpcloud.com/api/systemusers \
+                  -H 'Accept: application/json' \
+                  -H 'Content-Type: application/json' \
+                  -H x-api-key:$JC_SERVICE_API_KEY)
+                JC_USER_ID=$(echo $JC_SYSTEM_USERS | jq -r --arg EMAIL "$OWNER_EMAIL" '.results | .[] | select(.email==$EMAIL) | .id')
+                /usr/bin/curl -X POST https://console.jumpcloud.com/api/v2/users/$JC_USER_ID/associations \
+                  -H 'Accept: application/json' \
+                  -H 'Content-Type: application/json' \
+                  -H x-api-key:$JC_SERVICE_API_KEY \
+                  -d '{"attributes":{"sudo":{"enabled":true,"withoutPassword":false}},"op":"add","type":"system","id":"'$JC_SYSTEM_ID'"}'
+
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            # allow agent time to register with jumpcloud account
+            01_wait_registration:
+              command: "sleep 10"
+            02_associate_jc_systems:
+              command: "/opt/sage/bin/associate_jc_systems.sh"
+              env:
+                JC_SERVICE_API_KEY:
+                  Fn::Transform: {"Name": "SsmParam", "Parameters": {"Type": "SecureString", "Name": "/infra/JcServiceApiKey"}}
+        TagRootVolume:
+          commands:
+            01_tag_root_disk:
+              command: !Join
+                - ''
+                - - ". /opt/sage/bin/instance_env_vars.sh;"
+                  - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
+                  - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
+                  - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+        TagInstance:
+          files:
+            /opt/sage/bin/apply_name_tag.sh:
+              content: |
+                #! /bin/bash
+
+                set -xe
+
+                source /opt/sage/bin/instance_env_vars.sh
+                RESOURCE_ID=${STACK_ID##*/}
+                PRODUCTS=$(/usr/bin/aws --region $AWS_REGION \
+                  servicecatalog search-provisioned-products \
+                  --filters SearchQuery=$RESOURCE_ID )
+                NUM_PRODUCTS=$(echo $PRODUCTS | jq '.TotalResultsCount')
+                if ["$NUM_PRODUCTS" -ne 1]
+                then
+                  echo "ERROR: there are $NUM_PRODUCTS provisioned products, cannot isolate a name for tagging."
+                  exit 1
+                fi
+                NAME=$(echo $PRODUCTS | jq '.ProvisionedProducts[0].Name')
+                /usr/bin/aws ec2 create-tags --region $AWS_REGION \
+                  --resources $EC2_INSTANCE_ID \
+                  --tags Key=Name,Value=$NAME
+              mode: "00744"
+              owner: "root"
+              group: "root"
+          commands:
+            01_name_tag:
+              command: "/opt/sage/bin/apply_name_tag.sh"
+    Properties:
+      ImageId: !FindInMap [NotebookTypes, !Ref NotebookType, AMIID]
+      InstanceType: !Ref 'EC2InstanceType'
+      SubnetId: !If
+        - UsePublicSubnet
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+        - !ImportValue
+          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+      SecurityGroupIds: !If
+        - UsePublicSubnet
+        - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]
+        - [!Ref PrivateSubnetSecurityGroup]
+      KeyName: 'scipool'
+      BlockDeviceMappings:
+        -
+          DeviceName: "/dev/sda1"
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref VolumeSize
+            Encrypted: true
+      IamInstanceProfile: !Ref 'InstanceProfile'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          export DEBIAN_FRONTEND=noninteractive
+          /usr/bin/apt-get update -y
+          /usr/bin/apt-get install -y python-pip
+          /usr/bin/apt-get install -y python-setuptools
+          /bin/mkdir -p /opt/aws/bin /opt/sage/bin
+          /usr/bin/python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LinuxInstance --configsets SetupCfn,SetEnv,SetupJumpcloud,SetTags --region ${AWS::Region}
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource LinuxInstance --region ${AWS::Region}
+      Tags:
+        - Key: Name
+          Value: !Ref 'AWS::StackName'
+        - Key: Description
+          Value: !Sub "Service Catalog instance created by ${AWS::StackName}"
+        - Key: "parkmycloud"
+          Value: "yes"
+Outputs:
+  TemplateID:
+    Value: service-catalog-reference-architectures/sc-ec2-ra
+  AWSRegionName:
+    Value: !Ref 'AWS::Region'
+  LinuxInstanceId:
+    Value: !Ref 'LinuxInstance'
+  LinuxInstancePrivateIpAddress:
+    Value: !GetAtt 'LinuxInstance.PrivateIp'
+  LinuxInstanceAvailabilityZone:
+    Value: !GetAtt 'LinuxInstance.AvailabilityZone'
+  EC2InstanceType:
+    Value: !Ref 'EC2InstanceType'
+  IAMInstanceRole:
+    Value: !Ref 'InstanceRole'
+  IAMInstanceProfile:
+    Value: !Ref 'InstanceProfile'
+  ConnectionInstructions:
+    Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -7,7 +7,7 @@ Metadata:
           default: Linux Instance Configuration
         Parameters:
           - EC2InstanceType
-          - LinuxDistribution
+          - NotebookType
           - VolumeSize
           - PrivateNetwork
     ParameterLabels:

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -22,7 +22,7 @@ Metadata:
 Mappings:
   NotebookTypes:
     Rstudio:
-      AMIID: ami-036688a77595e31cf
+      AMIID: ami-036688a77595e31cf # from packer-rstudio build https://travis-ci.org/Sage-Bionetworks/packer-rstudio/builds/658411244
 Parameters:
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -190,8 +190,8 @@ Parameters:
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number
-    Default: 8
-    MinValue: 8
+    Default: 16
+    MinValue: 16
     MaxValue: 2000
 Conditions:
   UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Service Catalog: EC2 Reference Architecture.'
+Description: 'Service Catalog: Notebook Linux EC2 with Jumpcloud integration.'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/ec2/sc-portfolio-ec2-development.yaml
+++ b/ec2/sc-portfolio-ec2-development.yaml
@@ -127,7 +127,7 @@ Resources:
       PrincipalARN: !Sub 'arn:aws:iam::${AWS::AccountId}:group/${PrincipalGroupName2}'
       PortfolioId: !Ref 'SCEC2portfolio'
       PrincipalType: IAM
-  ec2linuxjumpcloudproduct:
+  Ec2LinuxJumpcloudProduct:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
@@ -141,7 +141,21 @@ Resources:
         StackDatetime: !Ref StackDatetime
       TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-linux-jumpcloud-development.yaml'
       TimeoutInMinutes: 5
-  ec2windowsjumpcloudproduct:
+  Ec2LinuxJumpcloudNotebookProduct:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        PortfolioProvider: !Ref 'PortfolioProvider'
+        LaunchConstraintARN: !If
+          - CreateLaunchConstraint
+          - !GetAtt 'LaunchConstraintRole.Outputs.LaunchRoleArn'
+          - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${LaunchRoleName}'
+        PortfolioId: !Ref 'SCEC2portfolio'
+        RepoRootURL: !Ref 'RepoRootURL'
+        StackDatetime: !Ref StackDatetime
+      TemplateURL: !Sub '${RepoRootURL}ec2/sc-product-ec2-linux-jumpcloud-notebook-development.yaml'
+      TimeoutInMinutes: 5
+  Ec2WindowsJumpcloudProduct:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:

--- a/ec2/sc-product-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/sc-product-ec2-linux-jumpcloud-notebook-development.yaml
@@ -1,0 +1,58 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: '[DEVELOPMENT] Notebook Linux EC2 ServiceCatalog product with Jumpcloud integration.'
+Parameters:
+  PortfolioProvider:
+    Type: String
+    Description: Owner and Distributor Name
+  LaunchConstraintARN:
+    Type: String
+    Description: ARN of the launch constraint role for EC2 products.
+  PortfolioId:
+    Type: String
+    Description: The ServiceCatalog portfolio this product will be attached to.
+  RepoRootURL:
+    Type: String
+    Description: Root url for the repo containing the product templates.
+  StackDatetime:
+    Type: String
+    Description: Last updated date and time of portfolio
+    Default: ''
+Resources:
+  ScEc2LinuxJumpcloudNotebookProduct:
+    Type: AWS::ServiceCatalog::CloudFormationProduct
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
+    Properties:
+      Name: '[DEVELOPMENT] Notebook Linux EC2 Instance with Jumpcloud Integration'
+      Description: This product builds one Linux EC2 instance using an Rstudio
+        AMI based on Ubuntu and maintained by Sage Bionetworks. 
+      Owner: !Ref 'PortfolioProvider'
+      Distributor: !Ref 'PortfolioProvider'
+      ProvisioningArtifactParameters:
+        - Description: !Sub 'DEVELOPMENT version. Last portfolio update occurred at ${StackDatetime}.'
+          Info:
+            LoadTemplateFromURL: !Sub '${RepoRootURL}ec2/sc-ec2-linux-jumpcloud-notebook-development.yaml'
+          Name: development
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location : "s3://cfn-snippets-bucket-cloudformationsnippetsbucket-elu83sv8ocdz/scipoolprod-sc-lib-infra/support.yaml"
+  Associateec2linux:
+    Type: AWS::ServiceCatalog::PortfolioProductAssociation
+    Properties:
+      PortfolioId: !Ref 'PortfolioId'
+      ProductId: !Ref 'ScEc2LinuxJumpcloudNotebookProduct'
+  constraintec2linux:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    DependsOn: Associateec2linux
+    Properties:
+      PortfolioId: !Ref 'PortfolioId'
+      ProductId: !Ref 'ScEc2LinuxJumpcloudNotebookProduct'
+      RoleArn: !Ref 'LaunchConstraintARN'
+      Description: !Ref 'LaunchConstraintARN'
+Outputs:
+  ProductId:
+    Value: !Ref 'ScEc2LinuxJumpcloudNotebookProduct'


### PR DESCRIPTION
Adds product and template for a Linux notebook product.
Currently the only choice for "Notebook Type" is Rstudio. Eventually we'll add Jupyter as an option too.

Note, this is only the development version, I'll have to create a PR for the actual product too.