### PR TITLE
Use packer-base-amazonlinux2 v1.0.1 

### DIFF
--- a/ec2/development/sc-ec2-linux-jumpcloud-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-development.yaml
@@ -27,7 +27,7 @@ Mappings:
     Ubuntu:
       AMIID: ami-093ca9e768e56b1bc  # https://github.com/Sage-Bionetworks/packer-base-ubuntu-bionic/tree/v1.0.6
     AmazonLinux:
-      AMIID: ami-0ca7208f904dc1874
+      AMIID: ami-06c6e00f3d3eaf56c  # https://github.com/Sage-Bionetworks/packer-base-amazonlinux2/tree/v1.0.1
 Parameters:
   PrivateNetwork:
     Type: String

--- a/ec2/development/tthyer/sc-ec2-linux-jumpcloud-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-ec2-linux-jumpcloud-development-tthyer.yaml
@@ -27,7 +27,7 @@ Mappings:
     Ubuntu:
       AMIID: ami-093ca9e768e56b1bc  # https://github.com/Sage-Bionetworks/packer-base-ubuntu-bionic/tree/v1.0.6
     AmazonLinux:
-      AMIID: ami-0ca7208f904dc1874
+      AMIID: ami-06c6e00f3d3eaf56c  # https://github.com/Sage-Bionetworks/packer-base-amazonlinux2/tree/v1.0.1
 Parameters:
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -27,7 +27,7 @@ Mappings:
     Ubuntu:
       AMIID: ami-093ca9e768e56b1bc  # https://github.com/Sage-Bionetworks/packer-base-ubuntu-bionic/tree/v1.0.6
     AmazonLinux:
-      AMIID: ami-0ca7208f904dc1874
+      AMIID: ami-06c6e00f3d3eaf56c  # https://github.com/Sage-Bionetworks/packer-base-amazonlinux2/tree/v1.0.1
 Parameters:
   PrivateNetwork:
     Type: String


### PR DESCRIPTION
Switch linux-jumpcloud product to use the packer-base-amazonlinux2 v1.0.1