### PR TITLE
[SC-111] Make templates reusable

### DIFF
--- a/ec2/development/sc-ec2-linux-jumpcloud-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-development.yaml
@@ -29,6 +29,10 @@ Mappings:
     AmazonLinux:
       AMIID: ami-06c6e00f3d3eaf56c  # https://github.com/Sage-Bionetworks/packer-base-amazonlinux2/tree/v1.0.1
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -233,10 +237,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -252,7 +256,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -412,9 +416,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/development/sc-ec2-linux-jumpcloud-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-development.yaml
@@ -31,7 +31,7 @@ Mappings:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/development/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -24,6 +24,10 @@ Mappings:
     Rstudio:
       AMIID: ami-0571ea73672b03ce7  # https://github.com/Sage-Bionetworks/packer-rstudio/tree/v1.0.1
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -226,10 +230,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -245,7 +249,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -399,9 +403,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/development/sc-ec2-linux-jumpcloud-notebook-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-notebook-development.yaml
@@ -26,7 +26,7 @@ Mappings:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/development/sc-ec2-linux-jumpcloud-workflows-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-workflows-development.yaml
@@ -19,7 +19,7 @@ Metadata:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/development/sc-ec2-linux-jumpcloud-workflows-development.yaml
+++ b/ec2/development/sc-ec2-linux-jumpcloud-workflows-development.yaml
@@ -17,6 +17,10 @@ Metadata:
       PrivateNetwork:
         default: Use private network?
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -213,10 +217,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -232,7 +236,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -395,9 +399,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/development/sc-ec2-windows-jumpcloud-development.yaml
+++ b/ec2/development/sc-ec2-windows-jumpcloud-development.yaml
@@ -14,6 +14,10 @@ Metadata:
       VolumeSize:
         default: Disk Size
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   WindowsInstanceType:
     AllowedValues:
       - t3.nano
@@ -61,14 +65,14 @@ Resources:
     Properties:
       GroupDescription: Enables RDP Access to Windows EC2 Instance
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: allow RDP
           IpProtocol: tcp
           FromPort: 3389
           ToPort: 3389
           CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
       SecurityGroupEgress:
         - Description: allow all outgoing
           IpProtocol: '-1'
@@ -222,7 +226,7 @@ Resources:
       ImageId: 'ami-074545a6fb2313e2c'
       InstanceType: !Ref 'WindowsInstanceType'
       SubnetId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet1'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet1'
       SecurityGroupIds:
         - !Ref 'WindowsSecurityGroup'
       KeyName: 'scipool'

--- a/ec2/development/sc-ec2-windows-jumpcloud-development.yaml
+++ b/ec2/development/sc-ec2-windows-jumpcloud-development.yaml
@@ -16,7 +16,7 @@ Metadata:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   WindowsInstanceType:
     AllowedValues:

--- a/ec2/development/tthyer/sc-ec2-linux-jumpcloud-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-ec2-linux-jumpcloud-development-tthyer.yaml
@@ -29,6 +29,10 @@ Mappings:
     AmazonLinux:
       AMIID: ami-06c6e00f3d3eaf56c  # https://github.com/Sage-Bionetworks/packer-base-amazonlinux2/tree/v1.0.1
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -233,10 +237,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -252,7 +256,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -412,9 +416,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/development/tthyer/sc-ec2-linux-jumpcloud-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-ec2-linux-jumpcloud-development-tthyer.yaml
@@ -31,7 +31,7 @@ Mappings:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml
@@ -24,7 +24,7 @@ Metadata:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PortfolioProvider:
     Type: String

--- a/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-portfolio-ec2-development-tthyer.yaml
@@ -22,6 +22,10 @@ Metadata:
         Parameters:
           - RepoRootURL
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PortfolioProvider:
     Type: String
     Description: Provider Name

--- a/ec2/development/tthyer/sc-product-ec2-linux-jumpcloud-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-product-ec2-linux-jumpcloud-development-tthyer.yaml
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: '[DEVELOPMENT-TTHYER] Linux EC2 ServiceCatalog product with Jumpcloud integration.'
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PortfolioProvider:
     Type: String
     Description: Owner and Distributor Name

--- a/ec2/development/tthyer/sc-product-ec2-linux-jumpcloud-development-tthyer.yaml
+++ b/ec2/development/tthyer/sc-product-ec2-linux-jumpcloud-development-tthyer.yaml
@@ -3,7 +3,7 @@ Description: '[DEVELOPMENT-TTHYER] Linux EC2 ServiceCatalog product with Jumpclo
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PortfolioProvider:
     Type: String

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -24,6 +24,10 @@ Mappings:
     Rstudio:
       AMIID: ami-0571ea73672b03ce7  # https://github.com/Sage-Bionetworks/packer-rstudio/tree/v1.0.1
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -226,10 +230,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -245,7 +249,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -399,9 +403,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-notebook-v1.0.0.yaml
@@ -26,7 +26,7 @@ Mappings:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -29,6 +29,10 @@ Mappings:
     AmazonLinux:
       AMIID: ami-06c6e00f3d3eaf56c  # https://github.com/Sage-Bionetworks/packer-base-amazonlinux2/tree/v1.0.1
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -233,10 +237,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -252,7 +256,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -412,9 +416,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -31,7 +31,7 @@ Mappings:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -19,7 +19,7 @@ Metadata:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String

--- a/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-workflows-v1.0.0.yaml
@@ -17,6 +17,10 @@ Metadata:
       PrivateNetwork:
         default: Use private network?
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   PrivateNetwork:
     Type: String
     Description: In the private subnet (recommended) as opposed to a public subnet
@@ -213,10 +217,10 @@ Resources:
       GroupDescription: >-
         Allow all traffic to an instance originating from the VPN
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
           FromPort: -1
           ToPort: -1
           IpProtocol: '-1'
@@ -232,7 +236,7 @@ Resources:
     Properties:
       GroupDescription: Allow SSH to port 22
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: 'allow SSH'
           IpProtocol: 'tcp'
@@ -395,9 +399,9 @@ Resources:
       SubnetId: !If
         - UsePublicSubnet
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PublicSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PublicSubnet'
         - !ImportValue
-          'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet'
+          'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet'
       SecurityGroupIds: !If
         - UsePublicSubnet
         - [!Ref PrivateSubnetSecurityGroup, !Ref PublicSubnetSecurityGroup]

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -14,6 +14,10 @@ Metadata:
       VolumeSize:
         default: Disk Size
 Parameters:
+  VpcName:
+    Type: String
+    Description: The vpc name used to reference resources
+    Default: 'internalpoolvpc'
   WindowsInstanceType:
     AllowedValues:
       - t3.nano
@@ -61,14 +65,14 @@ Resources:
     Properties:
       GroupDescription: Enables RDP Access to Windows EC2 Instance
       VpcId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-VPCId'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-VPCId'
       SecurityGroupIngress:
         - Description: allow RDP
           IpProtocol: tcp
           FromPort: 3389
           ToPort: 3389
           CidrIp: !ImportValue
-            'Fn::Sub': '${AWS::Region}-internalpoolvpc-VpnCidr'
+            'Fn::Sub': '${AWS::Region}-${VpcName}-VpnCidr'
       SecurityGroupEgress:
         - Description: allow all outgoing
           IpProtocol: '-1'
@@ -222,7 +226,7 @@ Resources:
       ImageId: 'ami-074545a6fb2313e2c'
       InstanceType: !Ref 'WindowsInstanceType'
       SubnetId: !ImportValue
-        'Fn::Sub': '${AWS::Region}-internalpoolvpc-PrivateSubnet1'
+        'Fn::Sub': '${AWS::Region}-${VpcName}-PrivateSubnet1'
       SecurityGroupIds:
         - !Ref 'WindowsSecurityGroup'
       KeyName: 'scipool'

--- a/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-windows-jumpcloud-v1.0.0.yaml
@@ -16,7 +16,7 @@ Metadata:
 Parameters:
   VpcName:
     Type: String
-    Description: The vpc name used to reference resources
+    Description: The VPC to put resources into
     Default: 'internalpoolvpc'
   WindowsInstanceType:
     AllowedValues:


### PR DESCRIPTION
Parameterize the vpc name to make templates more generic
so it can be re-used to deploy to multiple AWS accounts.

The purpose is to allow us to easily create the same SC in
another account for development.