### PR TITLE
[SC-26] template to create SC actions

### DIFF
--- a/ec2/sc-ec2-actions.yaml
+++ b/ec2/sc-ec2-actions.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: SC EC2 Actions
+Parameters:
+  AssumeRole:
+    Type: String
+    Description: The IAM role that SC actions will use
+Resources:
+  RestartEC2InstanceAction:
+    Type: Custom::ScActionsProvider
+    Properties:
+     ServiceToken: !ImportValue
+      'Fn::Sub': '${AWS::Region}-cfn-sc-actions-provider-CreateFunctionArn'
+     SsmDocName: "AWS-RestartEC2Instance"
+     SsmDocVersion: "1"
+     Name: !Sub '${AWS::StackName}-RestartEC2Instance'
+     AssumeRole: !Ref AssumeRole
+  StopEC2InstanceAction:
+    Type: Custom::ScActionsProvider
+    Properties:
+     ServiceToken: !ImportValue
+      'Fn::Sub': '${AWS::Region}-cfn-sc-actions-provider-CreateFunctionArn'
+     SsmDocName: "AWS-StopEC2Instance"
+     SsmDocVersion: "1"
+     Name: !Sub '${AWS::StackName}-StopEC2Instance'
+     AssumeRole: !Ref AssumeRole
+  StartEC2InstanceAction:
+    Type: Custom::ScActionsProvider
+    Properties:
+     ServiceToken: !ImportValue
+      'Fn::Sub': '${AWS::Region}-cfn-sc-actions-provider-CreateFunctionArn'
+     SsmDocName: "AWS-StartEC2Instance"
+     SsmDocVersion: "1"
+     Name: !Sub '${AWS::StackName}-StartEC2Instance'
+     AssumeRole: !Ref AssumeRole
+Outputs:
+  RestartEC2InstanceActionId:
+    Value: !Ref RestartEC2InstanceAction
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RestartEC2InstanceActionId'
+  StopEC2InstanceActionId:
+    Value: !Ref StopEC2InstanceAction
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RestartEC2InstanceActionId'
+  StartEC2InstanceActionId:
+    Value: !Ref StartEC2InstanceAction
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-StartEC2InstanceActionId'


### PR DESCRIPTION
This template can be used to create SC actions in an AWS account.
It depends on having the cfn-sc-actions-provider installed
PR https://github.com/Sage-Bionetworks/scipoolprod-infra/pull/91
installs the cfn-sc-actions-provider