### PR TITLE
Add StartSession policy for remote access

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -207,6 +207,48 @@ Conditions:
   UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']
   IsUbuntu: !Equals [!Ref LinuxDistribution, 'Ubuntu']
 Resources:
+  #TODO marker for proposed SSM connect policy
+  #TODO remove this snippet
+  AllowRemoteAccessThroughSSMPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowStartSession
+            Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource: 
+              - !GetAtt LinuxInstance.Arn
+          - Sid: AllowManageSessions
+            Effect: Allow
+            Action:
+              - ssm:DescribeSessions
+              - ssm:GetConnectionStatus
+              - ssm:DescribeInstanceProperties
+              - ec2:DescribeInstances
+            Resource:
+              - !GetAtt LinuxInstance.Arn
+          - Sid: SSM-SessionManagerRunShell
+            Effect: Allow
+            Action:
+              - ssm:GetDocument
+            Resource:
+              - 'arn:aws:ssm:::document/SSM-SessionManagerRunShell'
+          - Sid: AllowTerminateSession
+            Effect: Allow
+            Action:
+              - ssm:TerminateSession
+            Resource:
+              - !GetAtt LinuxInstance.Arn
+          - Sid: DenyOtherSSMActions
+            Effect: Deny
+            Action:
+              - ssm:*
+            NotResource:
+              - !GetAtt LinuxInstance.Arn
+      Roles: 'arn:aws:sts::AWS-account-ID:assumed-role/ServiceCatalogEndUsers/role-session-name'
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -216,6 +258,8 @@ Resources:
           'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - !Ref AllowRemoteAccessThroughSSMPolicy #TODO added
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" #TODO added to allow interaction with SSM service
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -207,48 +207,6 @@ Conditions:
   UsePublicSubnet: !Equals [!Ref PrivateNetwork, 'false']
   IsUbuntu: !Equals [!Ref LinuxDistribution, 'Ubuntu']
 Resources:
-  #TODO marker for proposed SSM connect policy
-  #TODO remove this snippet
-  AllowRemoteAccessThroughSSMPolicy:
-    Type: 'AWS::IAM::ManagedPolicy'
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AllowStartSession
-            Effect: Allow
-            Action:
-              - ssm:StartSession
-            Resource: 
-              - !GetAtt LinuxInstance.Arn
-          - Sid: AllowManageSessions
-            Effect: Allow
-            Action:
-              - ssm:DescribeSessions
-              - ssm:GetConnectionStatus
-              - ssm:DescribeInstanceProperties
-              - ec2:DescribeInstances
-            Resource:
-              - !GetAtt LinuxInstance.Arn
-          - Sid: SSM-SessionManagerRunShell
-            Effect: Allow
-            Action:
-              - ssm:GetDocument
-            Resource:
-              - 'arn:aws:ssm:::document/SSM-SessionManagerRunShell'
-          - Sid: AllowTerminateSession
-            Effect: Allow
-            Action:
-              - ssm:TerminateSession
-            Resource:
-              - !GetAtt LinuxInstance.Arn
-          - Sid: DenyOtherSSMActions
-            Effect: Deny
-            Action:
-              - ssm:*
-            NotResource:
-              - !GetAtt LinuxInstance.Arn
-      Roles: 'arn:aws:sts::AWS-account-ID:assumed-role/ServiceCatalogEndUsers/role-session-name'
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -258,8 +216,7 @@ Resources:
           'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
-        - !Ref AllowRemoteAccessThroughSSMPolicy #TODO added
-        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" #TODO added to allow interaction with SSM service
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" 
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -478,6 +435,9 @@ Resources:
           Value: !Sub "Service Catalog instance created by ${AWS::StackName}"
         - Key: "parkmycloud"
           Value: "yes"
+          #The session name appended to this roleid becomes the value of the AccessApprovedCaller tag
+        - Key: "AccessApprovedRoleId"
+          Value: !GetAtt 'ServiceCatalogEnduser.RoleId' 
 Outputs:
   TemplateID:
     Value: service-catalog-reference-architectures/sc-ec2-ra
@@ -497,3 +457,5 @@ Outputs:
     Value: !Ref 'InstanceProfile'
   ConnectionInstructions:
     Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
+  ConnectionURI:
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -18,6 +18,7 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
+        - !Ref SCEnduserRemoteAccessAllowed
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
@@ -27,6 +28,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
+        - !Ref SCEnduserRemoteAccessAllowed
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -51,6 +53,28 @@ Resources:
             Action:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
+            Resource: "*"
+  SCEnduserRemoteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allow calling StartSession on tagged instances
+      Path: "/"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource: "arn:aws:ec2::${AWS::AccountId}:instance/*"
+            Condition:
+              - StringLike:
+                - "ssm:ResourceTag/AccessApprovedCaller": "${aws:userid}"
+          - Effect: Allow
+            Action:
+              - ssm:DescribeSessions
+              - ssm:GetConnectionStatus
+              - ssm:DescribeInstanceProperties
+              - ec2:DescribeInstances
             Resource: "*"
   CFNDenyGetTemplateSummaryPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
@@ -85,3 +109,7 @@ Outputs:
     Value: !Ref SCEnduserExpandedPolicy
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SCEnduserExpandedPolicy'
+  EndUserRemoteAccessPolicy:
+    Value: !Ref SCEnduserRemoteAccessPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SCEnduserRemoteAccessPolicy'

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -18,7 +18,7 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
-        - !Ref SCEnduserRemoteAccessAllowed
+        - !Ref SCEnduserRemoteAccessPolicy
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
@@ -28,7 +28,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
-        - !Ref SCEnduserRemoteAccessAllowed
+        - !Ref SCEnduserRemoteAccessPolicy
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17


### PR DESCRIPTION
Passes pre-commit

This allows users to startsession on instances associated with their Synapse userid and adds the SSM core policy to a Linux instance profile. We can use this for other instance types, potentially.

Depends: 
- Adding tags for filtering startsession requests: https://github.com/Sage-Bionetworks/service-catalog-utils/pull/3
