### PR TITLE
SC-54 add start-session filter

### DIFF
--- a/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
+++ b/ec2/sc-ec2-linux-jumpcloud-v1.0.0.yaml
@@ -216,6 +216,7 @@ Resources:
           'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumePolicy'
         - !ImportValue
           'Fn::Sub': '${AWS::Region}-cfn-tag-instance-policy-TagInstancePolicy'
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" 
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -434,6 +435,9 @@ Resources:
           Value: !Sub "Service Catalog instance created by ${AWS::StackName}"
         - Key: "parkmycloud"
           Value: "yes"
+          #The session name appended to this roleid becomes the value of the AccessApprovedCaller tag
+        - Key: "AccessApprovedRoleId"
+          Value: !GetAtt 'ServiceCatalogEnduser.RoleId' 
 Outputs:
   TemplateID:
     Value: service-catalog-reference-architectures/sc-ec2-ra
@@ -453,3 +457,5 @@ Outputs:
     Value: !Ref 'InstanceProfile'
   ConnectionInstructions:
     Value: "https://sagebionetworks.jira.com/wiki/spaces/IT/pages/996376579/Connect+to+Provisioned+Instances"
+  ConnectionURI:
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/session-manager/${LinuxInstance}?region=${AWS::Region}"

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -65,10 +65,10 @@ Resources:
           - Effect: Allow
             Action:
               - ssm:StartSession
-            Resource: "arn:aws:ec2::${AWS::AccountId}:instance/*"
+            Resource: !Sub "arn:aws:ec2::${AWS::AccountId}:instance/*"
             Condition:
-              - StringLike:
-                - "ssm:ResourceTag/AccessApprovedCaller": "${aws:userid}"
+              StringLike:
+                "ssm:ResourceTag/AccessApprovedCaller": "${aws:userid}"
           - Effect: Allow
             Action:
               - ssm:DescribeSessions

--- a/iam/sc-enduser-iam.yaml
+++ b/iam/sc-enduser-iam.yaml
@@ -18,6 +18,7 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
+        - !Ref SCEnduserRemoteAccessPolicy
       Path: /
   SCEnduserRole:
     Type: AWS::IAM::Role
@@ -27,6 +28,7 @@ Resources:
         - arn:aws:iam::aws:policy/AWSServiceCatalogEndUserFullAccess
         - !Ref SCEnduserExpandedPolicy
         - !Ref CFNDenyGetTemplateSummaryPolicy
+        - !Ref SCEnduserRemoteAccessPolicy
       Path: /
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -51,6 +53,28 @@ Resources:
             Action:
               - organizations:DescribeOrganization
               - servicecatalog:DescribeProvisionedProduct
+            Resource: "*"
+  SCEnduserRemoteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allow calling StartSession on tagged instances
+      Path: "/"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource: "arn:aws:ec2::${AWS::AccountId}:instance/*"
+            Condition:
+              - StringLike:
+                - "ssm:ResourceTag/AccessApprovedCaller": "${aws:userid}"
+          - Effect: Allow
+            Action:
+              - ssm:DescribeSessions
+              - ssm:GetConnectionStatus
+              - ssm:DescribeInstanceProperties
+              - ec2:DescribeInstances
             Resource: "*"
   CFNDenyGetTemplateSummaryPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
@@ -85,3 +109,7 @@ Outputs:
     Value: !Ref SCEnduserExpandedPolicy
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SCEnduserExpandedPolicy'
+  EndUserRemoteAccessPolicy:
+    Value: !Ref SCEnduserRemoteAccessPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SCEnduserRemoteAccessPolicy'


### PR DESCRIPTION
This is a change to the ServiceCatalogEnduser role that allows an assumed role to call StartSession through the SSM service on instances tagged with the roleid and their unique sessionname. This PR is revised to correct an error in parsing allowed by this CFN version. I tested it in scipoolprod.